### PR TITLE
Update F-5 row in v0.2 roadmap

### DIFF
--- a/v0.2_roadmap.md
+++ b/v0.2_roadmap.md
@@ -37,7 +37,7 @@ Version 0.2 targets the **quality gap** revealed by the first ensemble release 
 | F‑2 | Bump `LogisticRegression(max_iter=1000)`; switch to `saga` if needed | ML    | Stacking warnings disappear          |       |                       |
 | F‑3 | Implement `CalibratedClassifierCV` for DT & RF                       | ML    | Calibration plot flat                |       |                       |
 | F‑4 | Global signal threshold policy (e.g., 0.65 buy, 0.35 sell)           | Strat | Trade counts stabilise across models |       |                       |
-| F‑5 | Position‑size weight =                                               | p‑0.5 |  × 2 (0–1) for *all* strategies      | Strat | Equity curve smoother |
+| F‑5 | Position‑size weight = p^-0.5 × 2 (0–1) for *all* strategies      | Strat | Equity curve smoother |       |                       |
 
 ### Phase 1 — Hyper‑parameter & Feature Boost (Week 3–4)
 


### PR DESCRIPTION
## Summary
- clarify position-size weighting formula in the Phase 0 table

## Testing
- `python3 test_probability_calibration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*