### PR TITLE
Fix doc table row and add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ This repository contains an implementation of a decision tree classifier for tra
 - Strategy Sharpe ratio > 1.0
 - Maximum drawdown < 25%
 
-See the documentation for more details on the implementation and roadmap.
+For more details on the strategy implementation, see the [Decision Tree Classifier Strategy](Decision_Tree_Classifier_Strategy.md) documentation.
+Planned improvements for version 0.2 are outlined in the [v0.2 Roadmap](v0.2_roadmap.md).

--- a/v0.2_roadmap.md
+++ b/v0.2_roadmap.md
@@ -37,7 +37,7 @@ Version 0.2 targets the **quality gap** revealed by the first ensemble release 
 | F‑2 | Bump `LogisticRegression(max_iter=1000)`; switch to `saga` if needed | ML    | Stacking warnings disappear          |       |                       |
 | F‑3 | Implement `CalibratedClassifierCV` for DT & RF                       | ML    | Calibration plot flat                |       |                       |
 | F‑4 | Global signal threshold policy (e.g., 0.65 buy, 0.35 sell)           | Strat | Trade counts stabilise across models |       |                       |
-| F‑5 | Position‑size weight =                                               | p‑0.5 |  × 2 (0–1) for *all* strategies      | Strat | Equity curve smoother |
+| F‑5 | Position‑size weight = p^-0.5 × 2 (0–1) for *all* strategies | Strat | Equity curve smoother |
 
 ### Phase 1 — Hyper‑parameter & Feature Boost (Week 3–4)
 


### PR DESCRIPTION
## Summary
- clarify position-size weight formula by keeping F-5 row on a single line
- link strategy docs and roadmap directly from the README

## Testing
- `pytest -q` *(fails: command not found)*