### PR TITLE
Implement StandardScaler pipelines

### DIFF
--- a/src/models/decision_tree_model.py
+++ b/src/models/decision_tree_model.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.calibration import CalibratedClassifierCV
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 from .base_model import BaseModel
 
 class DecisionTreeModel(BaseModel):
@@ -63,7 +65,7 @@ class DecisionTreeModel(BaseModel):
         }
         self.calibrate = calibrate
         self._base = DecisionTreeClassifier(**self.params)
-        self._clf = None
+        self._clf = None  # Will hold CalibratedClassifierCV or Pipeline
         self.feature_names = None
 
     def train(self, X, y):
@@ -85,18 +87,18 @@ class DecisionTreeModel(BaseModel):
         # Store feature names if available (for feature importance)
         self.feature_names = X.columns if hasattr(X, 'columns') else None
         
-        # Train the model
+        # Build a pipeline with scaling
+        pipeline = make_pipeline(StandardScaler(), self._base)
+
         if self.calibrate:
-            # First train the base estimator
-            self._base.fit(X, y)
-            # Wrap it in isotonic calibration
+            # Calibrate probabilities using isotonic regression
             self._clf = CalibratedClassifierCV(
-                self._base, method="isotonic", cv=5
+                pipeline, method="isotonic", cv=5
             )
             self._clf.fit(X, y)
         else:
-            self._base.fit(X, y)
-            self._clf = self._base
+            self._clf = pipeline
+            self._clf.fit(X, y)
         return self
 
     def predict(self, X):

--- a/src/models/random_forest_model.py
+++ b/src/models/random_forest_model.py
@@ -8,6 +8,8 @@ import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.calibration import CalibratedClassifierCV
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 from .base_model import BaseModel
 
 class RandomForestModel(BaseModel):
@@ -74,10 +76,10 @@ class RandomForestModel(BaseModel):
         }
         current_params.update(kwargs) # Update with any kwargs, including new ones like class_weight
 
-        self.params = current_params # Store all actual params used
+        self.params = current_params  # Store all actual params used
         self.calibrate = calibrate
         self._base = RandomForestClassifier(**self.params)
-        self._clf = None
+        self._clf = None  # Will hold CalibratedClassifierCV or Pipeline
         self.feature_names = None
 
     def train(self, X, y):
@@ -99,18 +101,18 @@ class RandomForestModel(BaseModel):
         # Store feature names if available (for feature importance)
         self.feature_names = X.columns if hasattr(X, 'columns') else None
         
-        # Train the model
+        # Build a pipeline with scaling
+        pipeline = make_pipeline(StandardScaler(), self._base)
+
         if self.calibrate:
-            # First train the base estimator
-            self._base.fit(X, y)
-            # Wrap it in isotonic calibration
+            # Calibrate probabilities using isotonic regression
             self._clf = CalibratedClassifierCV(
-                self._base, method="isotonic", cv=5
+                pipeline, method="isotonic", cv=5
             )
             self._clf.fit(X, y)
         else:
-            self._base.fit(X, y)
-            self._clf = self._base
+            self._clf = pipeline
+            self._clf.fit(X, y)
         return self
 
     def predict(self, X):

--- a/src/models/stacked_model.py
+++ b/src/models/stacked_model.py
@@ -72,7 +72,12 @@ class StackedModel(BaseModel):
         # Use appropriate meta-model based on type
         if meta_model_type == 'logistic_regression':
             from sklearn.linear_model import LogisticRegression
-            self.meta_model = LogisticRegression(**self.meta_model_params)
+            from sklearn.pipeline import make_pipeline
+            from sklearn.preprocessing import StandardScaler
+            self.meta_model = make_pipeline(
+                StandardScaler(),
+                LogisticRegression(max_iter=1000, solver='lbfgs', **self.meta_model_params)
+            )
         elif meta_model_type == 'random_forest':
             from sklearn.ensemble import RandomForestClassifier
             self.meta_model = RandomForestClassifier(**self.meta_model_params)

--- a/src/models/stacking_model.py
+++ b/src/models/stacking_model.py
@@ -40,10 +40,10 @@ class StackingModel(BaseModel):
         if hasattr(self, 'meta_model_sklearn') and self.meta_model_sklearn is not None:
             return self.meta_model_sklearn
         else:
-            # Create a new pipeline with StandardScaler + LogisticRegression with high max_iter
+            # Create a default meta-learner pipeline
             return make_pipeline(
                 StandardScaler(),
-                LogisticRegression(max_iter=5000, solver='lbfgs', n_jobs=-1)
+                LogisticRegression(max_iter=1000, solver='lbfgs', n_jobs=-1)
             )
     
     def __init__(self, base_models=None, meta_model=None, cv=5, use_features=False, 
@@ -87,7 +87,7 @@ class StackingModel(BaseModel):
                 params.update(self.meta_model_params)
                 self.meta_model_sklearn = make_pipeline(
                     StandardScaler(),
-                    LogisticRegression(max_iter=5000, solver='lbfgs', n_jobs=-1, **params)
+                    LogisticRegression(max_iter=1000, solver='lbfgs', n_jobs=-1, **params)
                 )
             elif meta_model_type == 'random_forest':
                 from sklearn.ensemble import RandomForestClassifier

--- a/src/models/xgboost_model.py
+++ b/src/models/xgboost_model.py
@@ -15,6 +15,8 @@ except ImportError:
     print("To install XGBoost: pip install xgboost")
 
 from .base_model import BaseModel
+from sklearn.pipeline import make_pipeline
+from sklearn.preprocessing import StandardScaler
 
 class XGBoostModel(BaseModel):
     """
@@ -23,6 +25,11 @@ class XGBoostModel(BaseModel):
     This class wraps XGBoost's XGBClassifier to conform
     to our BaseModel interface.
     """
+
+    @property
+    def model(self):
+        """Return the underlying XGBClassifier."""
+        return self._base
 
     def __init__(self, n_estimators=100, max_depth=5, learning_rate=0.1,
                  subsample=0.8, colsample_bytree=0.8, gamma=0, 
@@ -65,7 +72,8 @@ class XGBoostModel(BaseModel):
             'random_state': random_state,
             'n_jobs': n_jobs
         }
-        self.model = xgb.XGBClassifier(**self.params)
+        self._base = xgb.XGBClassifier(**self.params)
+        self._clf = None  # Will hold the pipeline
         self.feature_names = None
 
     def train(self, X, y):
@@ -87,8 +95,9 @@ class XGBoostModel(BaseModel):
         # Store feature names if available (for feature importance)
         self.feature_names = X.columns if hasattr(X, 'columns') else None
         
-        # Train the model
-        self.model.fit(X, y)
+        # Build pipeline with scaling
+        self._clf = make_pipeline(StandardScaler(), self._base)
+        self._clf.fit(X, y)
         return self
 
     def predict(self, X):
@@ -105,7 +114,7 @@ class XGBoostModel(BaseModel):
         np.ndarray
             Predicted probabilities for positive class (class 1)
         """
-        return self.model.predict_proba(X)[:, 1]  # Probability of positive class
+        return self._clf.predict_proba(X)[:, 1]  # Probability of positive class
 
     def get_feature_importance(self):
         """
@@ -117,10 +126,10 @@ class XGBoostModel(BaseModel):
             Feature importance scores
         """
         if self.feature_names is None:
-            return self.model.feature_importances_
+            return self._base.feature_importances_
         else:
             # Return dictionary mapping feature names to importance scores
-            return dict(zip(self.feature_names, self.model.feature_importances_))
+            return dict(zip(self.feature_names, self._base.feature_importances_))
 
     def save(self, path):
         """

--- a/src/strategies/base_strategy.py
+++ b/src/strategies/base_strategy.py
@@ -50,7 +50,8 @@ class BaseStrategy(ABC):
         float
             Position size (0-1 scale)
         """
-        return abs(prob - 0.5) * 2  # Scale to 0-1 linear weight
+        # Use square-root weighting for smoother sizing
+        return (abs(prob - 0.5) * 2) ** 0.5
 
     @abstractmethod
     def initialize(self, config):


### PR DESCRIPTION
## Summary
- wrap DecisionTreeModel with a `StandardScaler` pipeline
- wrap RandomForestModel with a `StandardScaler` pipeline
- add scaling pipeline for XGBoostModel
- use pipelines for stacking meta-models and adjust LogisticRegression `max_iter`
- change position sizing rule to square-root weighting

## Testing
- `python test_probability_calibration.py` *(fails: No module named 'numpy')*