### PR TITLE
Implement global signal thresholds

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -269,8 +269,8 @@ def run_walkforward_backtest(data_path, output_dir='results_walkforward',
         slippage=config.SLIPPAGE_RATE
     )
     
-    # Run walkforward backtest
-    results = backtester.run(signal_threshold=threshold)
+    # Run walkforward backtest using global thresholds
+    results = backtester.run()
     
     # Print performance summary
     performance = results['performance']

--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -294,7 +294,7 @@ class WalkforwardBacktester:
         self.commission = commission
         self.slippage = slippage
         
-    def run(self, symbol='SPY', min_train_samples=252, signal_threshold=0.65):
+    def run(self, symbol='SPY', min_train_samples=252):
         """
         Run walkforward backtest.
         
@@ -304,8 +304,7 @@ class WalkforwardBacktester:
             Trading symbol
         min_train_samples : int, default=252
             Minimum number of samples required for training
-        signal_threshold : float, default=0.65
-            Threshold for generating trading signals
+            (global BUY/SELL thresholds from BaseStrategy are used)
             
         Returns:
         --------
@@ -366,7 +365,7 @@ class WalkforwardBacktester:
             
             # Generate signals
             print(f"  Generating signals for {len(X_test)} test samples...")
-            signals = generate_signals(model, X_test, dates_test, symbol, threshold=signal_threshold)
+            signals = generate_signals(model, X_test, dates_test, symbol)
             
             # Run backtest
             print(f"  Running backtest...")

--- a/src/backtesting/signal_generation.py
+++ b/src/backtesting/signal_generation.py
@@ -5,9 +5,10 @@ Module for generating trading signals from model predictions.
 
 import pandas as pd
 import numpy as np
+from src.strategies.base_strategy import BUY_THRESHOLD, SELL_THRESHOLD
 
 
-def generate_signals(model, X, dates, symbol='SPY', threshold=0.65):
+def generate_signals(model, X, dates, symbol='SPY'):
     """
     Generate trading signals from model predictions.
     
@@ -21,8 +22,6 @@ def generate_signals(model, X, dates, symbol='SPY', threshold=0.65):
         Dates corresponding to the feature matrix rows
     symbol : str, default='SPY'
         Trading symbol
-    threshold : float, default=0.65
-        Probability threshold for generating buy signals
         
     Returns:
     --------
@@ -36,17 +35,17 @@ def generate_signals(model, X, dates, symbol='SPY', threshold=0.65):
     if not isinstance(dates, pd.Series):
         dates = pd.Series(dates)
     
-    # Create signals DataFrame
+    # Create signals DataFrame using global thresholds
     signals = []
     for i in range(len(X)):
-        if proba[i] > threshold:  # Strong buy signal
+        if proba[i] > BUY_THRESHOLD:  # Buy signal
             signals.append({
                 'date': dates.iloc[i],
                 'symbol': symbol,
                 'signal': 1,  # Buy
                 'probability': proba[i]
             })
-        elif proba[i] < 1 - threshold:  # Strong sell signal
+        elif proba[i] < SELL_THRESHOLD:  # Sell signal
             signals.append({
                 'date': dates.iloc[i],
                 'symbol': symbol,

--- a/test_probability_calibration.py
+++ b/test_probability_calibration.py
@@ -7,11 +7,14 @@ import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 from src.models.model_factory import ModelFactory
+from src.strategies.base_strategy import BUY_THRESHOLD, SELL_THRESHOLD
 
 def main():
     print('Creating test data...')
     X, y = make_classification(n_samples=1000, n_features=20, random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    print(f'\nGlobal thresholds: buy={BUY_THRESHOLD}, sell={SELL_THRESHOLD}')
 
     print('\nTesting DecisionTree with calibration...')
     dt = ModelFactory.create_model('decision_tree', calibrate=True)


### PR DESCRIPTION
## Summary
- enforce global BUY/SELL thresholds in backtest helpers
- drop threshold parameter in walkforward backtester and test harness
- expose global thresholds in the probability calibration test

## Testing
- `python test_probability_calibration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*