### PR TITLE
Remove deprecated threshold parameter references

### DIFF
--- a/src/engines/signal_engine.py
+++ b/src/engines/signal_engine.py
@@ -21,10 +21,9 @@ class SignalEngine:
         Parameters:
         -----------
         position_sizing : str, default=None
-            Legacy parameter - using probability-based sizing now
+            Position sizing method
         """
-        # Kept for backward compatibility, but not used anymore
-        # Global thresholds BUY_THRESHOLD and SELL_THRESHOLD are used instead
+        # Kept for backward compatibility
         self.position_sizing = position_sizing
 
     def generate_signals(self, predictions, dates, symbol='SPY'):
@@ -53,7 +52,7 @@ class SignalEngine:
         signals = []
 
         for i, probability in enumerate(predictions):
-            # Determine signal based on threshold
+            # Determine signal using global thresholds
             if probability >= BUY_THRESHOLD:  # Buy signal
                 signal = 1
             elif probability <= SELL_THRESHOLD:  # Sell signal

--- a/src/strategies/trend_following.py
+++ b/src/strategies/trend_following.py
@@ -28,7 +28,6 @@ class TrendFollowingStrategy(BaseStrategy):
             Strategy configuration with keys:
             - model_type (str): Type of model to use
             - model_params (dict): Model parameters
-            - threshold (float): Signal threshold (deprecated - using global thresholds now)
             - position_sizing (str): Position sizing method (deprecated - using probability-based sizing now)
         """
         # Store configuration


### PR DESCRIPTION
## Summary
- cleaned up `SignalEngine.__init__` docstring
- removed outdated threshold comment
- updated `TrendFollowingStrategy` docs to stop mentioning threshold parameter

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
- `python test_probability_calibration.py` *(fails: No module named numpy)*