### PR TITLE
Implement capital adjustments in backtesting

### DIFF
--- a/src/backtesting/signal_generation.py
+++ b/src/backtesting/signal_generation.py
@@ -123,7 +123,9 @@ def calculate_positions(signals_df, initial_capital=100000, price_data=None):
     initial_capital : float, default=100000
         Initial capital
     price_data : pd.DataFrame, optional
-        Price data with columns: date, close
+        Price data indexed by date with a ``close`` column representing the
+        security price in the same currency as ``initial_capital``.  Only the
+        ``close`` column is used.
         
     Returns:
     --------
@@ -143,7 +145,10 @@ def calculate_positions(signals_df, initial_capital=100000, price_data=None):
     
     for i in range(len(positions_df)):
         signal = positions_df.iloc[i]['signal']
-        
+
+        # Track previous position to determine if a trade occurs
+        prev_position = position
+
         # Update position based on signal
         if signal == 1:  # Buy
             position = 1
@@ -158,7 +163,12 @@ def calculate_positions(signals_df, initial_capital=100000, price_data=None):
             date = positions_df.iloc[i]['date']
             if date in price_data.index:
                 price = price_data.loc[date, 'close']
-                # TODO: Implement capital calculation
+
+                # Deduct cost on buy and add proceeds on sell
+                if position > prev_position:
+                    capital -= price
+                elif position < prev_position:
+                    capital += price
         
         # Store capital
         positions_df.iloc[i, positions_df.columns.get_loc('capital')] = capital


### PR DESCRIPTION
## Summary
- document price data assumptions for `calculate_positions`
- deduct cost on buy and add proceeds on sell when price data is provided

## Testing
- `python test_probability_calibration.py` *(fails: ModuleNotFoundError for numpy)*