### PR TITLE
Fix capital tracking in calculate_positions

### DIFF
--- a/src/backtesting/signal_generation.py
+++ b/src/backtesting/signal_generation.py
@@ -142,7 +142,8 @@ def calculate_positions(signals_df, initial_capital=100000, price_data=None):
     # Calculate positions
     position = 0
     capital = initial_capital
-    
+    prev_position = 0
+
     for i in range(len(positions_df)):
         signal = positions_df.iloc[i]['signal']
 


### PR DESCRIPTION
## Summary
- track `prev_position` across iterations in `calculate_positions`

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `python3 test_probability_calibration.py` *(fails: No module named numpy)*