### PR TITLE
Remove unused threshold attribute

### DIFF
--- a/src/engines/signal_engine.py
+++ b/src/engines/signal_engine.py
@@ -21,9 +21,7 @@ class SignalEngine:
             Legacy parameter retained for backward compatibility. Position
             sizing now relies solely on probability distance from 0.5.
         """
-        # Global BUY_THRESHOLD and SELL_THRESHOLD are used instead of a
-        # per-engine value. The attribute is kept to avoid breaking old code.
-        self.threshold = None
+        # Signals rely on the module-level BUY_THRESHOLD and SELL_THRESHOLD.
         self.position_sizing = position_sizing
 
 


### PR DESCRIPTION
## Summary
- stop storing unused `threshold` attribute in `SignalEngine`
- keep initialization docs clean about removed param

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*