### PR TITLE
Allow fixed position sizing

### DIFF
--- a/src/strategies/trend_following.py
+++ b/src/strategies/trend_following.py
@@ -28,6 +28,8 @@ class TrendFollowingStrategy(BaseStrategy):
             Strategy configuration with keys:
             - model_type (str): Type of model to use
             - model_params (dict): Model parameters
+            - position_sizing (str, optional): Position sizing method for
+              ``SignalEngine`` ('fixed' or 'confidence')
         """
         # Store configuration
         self.config = config
@@ -38,8 +40,10 @@ class TrendFollowingStrategy(BaseStrategy):
         
         # Initialize engines
         self.model_engine = ModelEngine(self.model_type, self.model_params)
-        # Use global thresholds and probability-based position sizing
-        self.signal_engine = SignalEngine()
+
+        # Position sizing method for SignalEngine
+        self.position_sizing = config.get('position_sizing', 'confidence')
+        self.signal_engine = SignalEngine(position_sizing=self.position_sizing)
         
         # Store strategy state
         self.is_trained = False

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -142,7 +142,8 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
             'name': 'XGBoost',
             'model_type': 'xgboost',
             'model_params': {'n_estimators': 100, 'max_depth': 5, 'learning_rate': 0.1},
-            'symbol': symbol
+            'symbol': symbol,
+            'position_sizing': 'fixed'
         })
         
         strategy_configs.append({


### PR DESCRIPTION
## Summary
- add `position_sizing` option to `TrendFollowingStrategy.initialize`
- pass that option to `SignalEngine`
- set the XGBoost comparison run to use fixed sizing

## Testing
- `python test_probability_calibration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*