### PR TITLE
Add lower threshold support for regimes

### DIFF
--- a/Decision_Tree_Classifier_Strategy.md
+++ b/Decision_Tree_Classifier_Strategy.md
@@ -555,6 +555,10 @@ The regime-adaptive strategy adjusts risk parameters based on the detected marke
 3. **Neutral**: Reduced position sizing, higher entry threshold
 4. **Weak Downtrend**: Minimal position sizing, very high entry threshold
 5. **Strong Downtrend**: Extremely conservative or avoid trading
+6. **Custom Thresholds**: Specify `buy_threshold` and `sell_threshold` in
+   `regime_params` to override the default 0.65/0.35 levels. Setting
+   `use_low_thresholds: true` applies 0.55 and 0.45 by default if specific
+   values are not provided.
 
 ## Performance Evaluation
 

--- a/src/strategies/regime_adaptive_strategy.py
+++ b/src/strategies/regime_adaptive_strategy.py
@@ -223,9 +223,15 @@ class RegimeAdaptiveStrategy(TrendFollowingStrategy):
         
         # Override with regime-specific parameters if available
         if regime_label in self.regime_params:
-            regime_specific = self.regime_params.get(regime_label, {})
+            regime_specific = self.regime_params.get(regime_label, {}).copy()
+
+            # Apply lower thresholds if requested and explicit values aren't provided
+            use_low = regime_specific.pop('use_low_thresholds', False)
             params.update(regime_specific)
-        
+            if use_low:
+                params['buy_threshold'] = params.get('buy_threshold', 0.55)
+                params['sell_threshold'] = params.get('sell_threshold', 0.45)
+
         return params
 
     def generate_signals(self, features, predictions, dates):


### PR DESCRIPTION
## Summary
- allow RegimeAdaptiveStrategy to apply lower buy/sell thresholds via `use_low_thresholds`
- document new regime parameters in strategy guide

## Testing
- `pip install pytest` *(fails: Could not connect to proxy)*
- `python test_probability_calibration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*