### PR TITLE
Improve position sizing handling

### DIFF
--- a/Decision_Tree_Classifier_Strategy.md
+++ b/Decision_Tree_Classifier_Strategy.md
@@ -309,6 +309,25 @@ python strategy_runner.py --data data/raw --model xgboost
 python strategy_runner.py --data data/raw --model stacking
 ```
 
+#### Position Sizing Options
+
+`TrendFollowingStrategy` supports two position sizing modes via the
+`position_sizing` configuration key:
+
+- **fixed** – every trade uses the same size.
+- **confidence** – position size scales with prediction confidence (default).
+
+Example configuration snippet:
+
+```python
+{
+    'name': 'XGBoost',
+    'model_type': 'xgboost',
+    'model_params': {...},
+    'position_sizing': 'fixed'
+}
+```
+
 #### Creating Custom Strategies
 
 To create a custom strategy:

--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -110,9 +110,11 @@ class BacktestEngine:
                 
                 # Process signal
                 if signal == 1 and symbol not in self.positions:  # Buy
-                    # Calculate position size (equal weight for simplicity)
+                    # Calculate position size
+                    # Use signal's suggested position size fraction if provided
+                    size_fraction = signal_row.get('position_size', 1.0)
                     available_capital = self.capital * 0.95  # Keep some cash
-                    position_size = available_capital / price
+                    position_size = (available_capital * size_fraction) / price
                     cost = position_size * price * (1 + self.slippage) * (1 + self.commission)
                     
                     if cost <= self.capital:

--- a/src/engines/model_engine.py
+++ b/src/engines/model_engine.py
@@ -3,6 +3,7 @@ Model engine for training, evaluating, and managing models.
 """
 
 import os
+import warnings
 import numpy as np
 import pandas as pd
 from sklearn.model_selection import cross_val_score
@@ -252,8 +253,12 @@ class ModelEngine:
             
             sklearn_model = ModelWrapper(self.model)
         
-        # Perform cross-validation
-        return cross_val_score(sklearn_model, X, y, cv=cv, scoring='accuracy')
+        # Perform cross-validation, suppressing runtime warnings from sklearn
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            scores = cross_val_score(sklearn_model, X, y, cv=cv, scoring='accuracy')
+
+        return scores
     
     def _perform_hpo(self, X, y, param_grid, cv=3, scoring='accuracy'):
         """

--- a/src/strategies/regime_adaptive_strategy.py
+++ b/src/strategies/regime_adaptive_strategy.py
@@ -296,6 +296,11 @@ class RegimeAdaptiveStrategy(TrendFollowingStrategy):
             # Adjust position size based on regime
             position_size_pct = params.get('position_size_pct', 0.1)
             signals.loc[date, 'position_size_pct'] = position_size_pct
+            # Scale the existing position_size from SignalEngine
+            if 'position_size' in signals.columns:
+                signals.loc[date, 'position_size'] = (
+                    signals.loc[date, 'position_size'] * position_size_pct
+                )
             
             # Add stop loss and take profit levels if specified
             stop_loss_pct = params.get('stop_loss_pct')


### PR DESCRIPTION
## Summary
- use signal-based sizing in BacktestEngine
- scale position sizes per regime
- suppress spurious runtime warnings
- document position sizing option

## Testing
- `python3 test_probability_calibration.py` *(fails: ModuleNotFoundError: No module named 'numpy')*