### PR TITLE
Fix: Resolve duplicate max_iter parameter in StackingModel

### DIFF
--- a/src/models/stacking_model.py
+++ b/src/models/stacking_model.py
@@ -98,12 +98,22 @@ class StackingModel(BaseModel):
             
             if meta_model_type == 'logistic_regression':
                 params = {'C': 1.0, 'random_state': 42}
-                params.update(self.meta_model_params)
-                # Meta learner pipeline leveraging saga solver and all cores
-                self.meta_model_sklearn = make_pipeline(
-                    StandardScaler(),
-                    LogisticRegression(max_iter=1000, solver='saga', n_jobs=-1, **params)
-                )
+                # Fix: Remove 'max_iter' from params if it's already specified explicitly
+                if 'max_iter' in self.meta_model_params:
+                    max_iter = self.meta_model_params.pop('max_iter')
+                    params.update(self.meta_model_params)
+                    # Use the max_iter from meta_model_params
+                    self.meta_model_sklearn = make_pipeline(
+                        StandardScaler(),
+                        LogisticRegression(max_iter=max_iter, solver='saga', n_jobs=-1, **params)
+                    )
+                else:
+                    params.update(self.meta_model_params)
+                    # Meta learner pipeline leveraging saga solver and all cores
+                    self.meta_model_sklearn = make_pipeline(
+                        StandardScaler(),
+                        LogisticRegression(max_iter=1000, solver='saga', n_jobs=-1, **params)
+                    )
             elif meta_model_type == 'random_forest':
                 from sklearn.ensemble import RandomForestClassifier
                 params = {'n_estimators': 100, 'max_depth': 3, 'random_state': 42}
@@ -340,4 +350,3 @@ class StackingModel(BaseModel):
             meta_model_str = "None"
             
         return f"StackingModel(base_models={len(self.base_models)}, meta_model={meta_model_str}, cv={self.cv})"
-


### PR DESCRIPTION
## Fix for Stacking Ensemble LogisticRegression Error

### Issue Description
When running the strategy comparison with the Stacking Ensemble model, we encountered the following error:
```
TypeError: sklearn.linear_model._logistic.LogisticRegression() got multiple values for keyword argument 'max_iter'
```

### Root Cause
This error occurs because the `max_iter` parameter is being specified twice:
1. It's explicitly set in the LogisticRegression constructor: `LogisticRegression(max_iter=1000, ...)`
2. It's also included in the `meta_model_params` dictionary that's passed to the constructor via `**params`

Looking at our configuration in strategy_configs.py, we set:
```python
'meta_model_params': {'C': 1.0, 'max_iter': 1000}
```
And in the stacking_model.py implementation, this gets passed to the LogisticRegression constructor which already has a hardcoded `max_iter=1000`.

### Fix
Modified the `__init__` method in the StackingModel class to check if 'max_iter' is present in the meta_model_params dictionary:
1. If it's present, extract it and use that value explicitly in the constructor
2. If it's not present, use the default value of 1000

This ensures the parameter isn't passed twice, preventing the duplication error.

### Testing
The change should allow the Stacking Ensemble model to run successfully without encountering the duplicate parameter error.