### PR TITLE
Fix XGBoost availability check in optimize_hyperparameters.py

### DIFF
--- a/optimize_hyperparameters.py
+++ b/optimize_hyperparameters.py
@@ -20,6 +20,15 @@ import pandas as pd
 import numpy as np
 from datetime import datetime
 
+# Check for XGBoost availability
+try:
+    import xgboost as xgb
+    XGBOOST_AVAILABLE = True
+except ImportError:
+    XGBOOST_AVAILABLE = False
+    print("Warning: XGBoost is not installed. XGBoost optimization will not be available.")
+    print("To install XGBoost: pip install xgboost")
+
 from src.data.preprocessing import preprocess_data
 from src.features.regime_detection import RegimeDetector
 from src.models.hyperparameter_manager import HyperparameterManager


### PR DESCRIPTION
## Fix for XGBoost Availability Check

This PR addresses an error in the `optimize_hyperparameters.py` script that occurs when trying to run hyperparameter optimization.

### Problem

When running `python optimize_hyperparameters.py --data data/raw --model all`, the script fails with the following error:

```
NameError: name 'XGBOOST_AVAILABLE' is not defined
```

This occurs because the script was trying to use the `XGBOOST_AVAILABLE` variable imported from `model_factory.py`, but this variable was only used in the scope of that module and not actually exported.

### Solution

Added a proper XGBoost availability check at the beginning of the `optimize_hyperparameters.py` file:

```python
# Check for XGBoost availability
try:
    import xgboost as xgb
    XGBOOST_AVAILABLE = True
except ImportError:
    XGBOOST_AVAILABLE = False
    print("Warning: XGBoost is not installed. XGBoost optimization will not be available.")
    print("To install XGBoost: pip install xgboost")
```

This explicitly defines the `XGBOOST_AVAILABLE` variable in the script, rather than relying on importing it from another module.

### Testing

The script now runs successfully with the fixed code and properly handles XGBoost availability.