### PR TITLE
Fix Pipeline Warnings in XGBoost Hyperparameter Optimization

### DIFF
--- a/src/models/hyperparameter_optimization.py
+++ b/src/models/hyperparameter_optimization.py
@@ -234,15 +234,18 @@ def optimize_xgboost(X, y, n_trials=100, n_splits=5, random_state=42):
                     
                     # Import from src
                     from src.models.xgboost_model import XGBoostModel
+                    from sklearn.pipeline import make_pipeline
+                    from sklearn.preprocessing import StandardScaler
                     
                     # Create a dedicated XGBoostModel with current trial parameters
                     custom_model = XGBoostModel(**params)
                     
-                    # Train the model on this fold
-                    custom_model.train(X_train, y_train)
+                    # Create a proper pipeline for each fold and explicitly fit it
+                    pipeline = make_pipeline(StandardScaler(), custom_model)
+                    pipeline.fit(X_train, y_train)
                     
-                    # Get predictions
-                    y_pred = custom_model.predict(X_test)
+                    # Use the pipeline for prediction
+                    y_pred = pipeline.predict_proba(X_test)[:, 1]  # Get probabilities for positive class
                     y_pred_binary = (y_pred > 0.5).astype(int)
                     
                     # Calculate accuracy


### PR DESCRIPTION
## Overview
This PR fixes the pipeline warnings that were occurring during hyperparameter optimization. The warning was:

```
This Pipeline instance is not fitted yet. Call 'fit' with appropriate arguments before using other methods such as transform, predict, etc. This will raise an error in 1.8 instead of the current warning.
```

## What Changed
1. Modified the `custom_cv_score` function in `optimize_xgboost()` to:
   - Create a proper scikit-learn pipeline with StandardScaler and XGBoostModel for each cross-validation fold
   - Explicitly fit the pipeline before using it for predictions
   - Use pipeline's predict_proba method for consistent interface

## Why This Matters
1. This warning will become an error in scikit-learn 1.8, breaking our hyperparameter optimization
2. Addresses Phase 0 task F-1 from the v0.2 roadmap: "Add `StandardScaler`+`Pipeline` around all models"
3. Ensures that our preprocessing steps are properly applied in the same way for both training and prediction

## Testing Done
The fix has been implemented based on the analysis of the test results from running the hyperparameter optimization script. Once deployed, the pipeline warnings should disappear as we're now explicitly fitting each pipeline before use.

## Next Steps
After this PR is merged, we can proceed with the remaining tasks in Phase 2 of the roadmap.