### PR TITLE
Fix XGBoost model to properly implement scikit-learn estimator interface

### DIFF
--- a/src/models/xgboost_model.py
+++ b/src/models/xgboost_model.py
@@ -187,12 +187,12 @@ class FocalLoss:
         
         return grad, hess
 
-class XGBoostModel(BaseModel):
+class XGBoostModel(BaseModel, BaseEstimator, ClassifierMixin):
     """
     XGBoost implementation of the BaseModel interface.
     
     This class wraps XGBoost's XGBClassifier to conform
-    to our BaseModel interface.
+    to our BaseModel interface and scikit-learn's estimator interface.
     """
 
     @property
@@ -283,7 +283,46 @@ class XGBoostModel(BaseModel):
         self._base = xgb.XGBClassifier(**self.params)
         self._clf = None  # Will hold the pipeline
         self.feature_names = None
+        
+        # For scikit-learn compatibility, store all parameters as attributes
+        self.n_estimators = n_estimators
+        self.max_depth = max_depth
+        self.learning_rate = learning_rate
+        self.subsample = subsample
+        self.colsample_bytree = colsample_bytree
+        self.gamma = gamma
+        self.objective = objective
+        self.random_state = random_state
+        self.n_jobs = n_jobs
+        self.min_child_weight = min_child_weight
+        self.reg_alpha = reg_alpha
+        self.reg_lambda = reg_lambda
+        self.scale_pos_weight = scale_pos_weight
 
+    def fit(self, X, y, sample_weight=None):
+        """
+        Fit the model to the data (scikit-learn compatible method).
+        
+        This is a wrapper around the train method to make it compatible
+        with scikit-learn's estimator interface.
+        
+        Parameters:
+        -----------
+        X : pd.DataFrame or np.ndarray
+            Feature matrix
+        y : pd.Series or np.ndarray
+            Target values
+        sample_weight : array-like or None, default=None
+            Sample weights
+            
+        Returns:
+        --------
+        self
+            For method chaining
+        """
+        # Use our existing train method
+        return self.train(X, y)
+        
     def train(self, X, y):
         """
         Train the model on given data.
@@ -391,6 +430,23 @@ class XGBoostModel(BaseModel):
         """
         # Always use predict_proba from the pipeline
         return self._clf.predict_proba(X)[:, 1]  # Probability of positive class
+        
+    def predict_proba(self, X):
+        """
+        Generate probability predictions (scikit-learn compatible method).
+        
+        Parameters:
+        -----------
+        X : pd.DataFrame or np.ndarray
+            Feature matrix
+            
+        Returns:
+        --------
+        np.ndarray
+            Array with probabilities for both classes
+        """
+        # Use the pipeline's predict_proba method
+        return self._clf.predict_proba(X)
 
     def get_feature_importance(self):
         """


### PR DESCRIPTION
## Overview
This PR fixes the TypeError that occurred when using XGBoostModel in a scikit-learn pipeline during hyperparameter optimization. The error was:

```
TypeError: Last step of Pipeline should implement fit or be the string 'passthrough'. 'XGBoostModel(...) doesn't
```

## What Changed
1. Made `XGBoostModel` properly inherit from scikit-learn's `BaseEstimator` and `ClassifierMixin`
2. Added a scikit-learn compatible `fit()` method that works with the pipeline
3. Added a proper `predict_proba()` method that returns probabilities for both classes
4. Stored all parameters as object attributes to ensure compatibility with scikit-learn's get_params/set_params mechanism

## Why This Matters
1. Fixes the hyperparameter optimization process for XGBoost models
2. Ensures our custom models can properly integrate with scikit-learn's pipeline mechanism
3. Makes our code more interoperable with scikit-learn's ecosystem
4. Allows our previous pipeline warning fix to work correctly

## Testing
This change should allow the optimization process to run without the TypeError when creating a pipeline with our XGBoostModel. The model's behavior should remain unchanged since we've maintained all the existing functionality.

## Next Steps
After this PR is merged, we should be able to run the hyperparameter optimization process without errors, completing Phase 0 task F-1 from the v0.2 roadmap.