### PR TITLE
Fix transformer wrapper edge cases and tests

### DIFF
--- a/scripts/README_TRANSFORMER.md
+++ b/scripts/README_TRANSFORMER.md
@@ -43,8 +43,12 @@ This directory contains the transformer module implementation for integration wi
 ### 1. Install Dependencies
 
 ```bash
-pip install torch numpy pandas scikit-learn ta
+pip install -r scripts/requirements_transformer.txt
 ```
+
+Requires **Python 3.10+** and a compatible PyTorch build. Install the CPU or GPU
+version of PyTorch depending on your hardware. The `ta` library is optional but
+recommended.
 
 ### 2. Basic Usage
 
@@ -62,6 +66,7 @@ transformer = TransformerModelWrapper(
     n_features=9,
     d_model=64,
     n_heads=8,
+    target_column='close',
     epochs=20
 )
 
@@ -136,8 +141,20 @@ from scripts.hybrid_strategy import HybridTransformerStrategy
 
 class HybridMLStrategy(BaseStrategy, HybridTransformerStrategy):
     """Unified hybrid strategy for the system."""
-    pass
+
+    def __init__(self, dt_model, tf_model, regime_detector):
+        BaseStrategy.__init__(self)
+        HybridTransformerStrategy.__init__(
+            self,
+            dt_model=dt_model,
+            tf_model=tf_model,
+            regime_detector=regime_detector,
+        )
 ```
+
+Calling both parent constructors ensures attributes from `BaseStrategy` and
+`HybridTransformerStrategy` are initialized correctly when using multiple
+inheritance.
 
 ## Architecture Benefits
 
@@ -178,10 +195,10 @@ class HybridMLStrategy(BaseStrategy, HybridTransformerStrategy):
 
 ## Testing
 
-Run the integration test:
+Run the automated test suite:
 
 ```bash
-python scripts/test_transformer_integration.py
+pytest
 ```
 
 Expected output:

--- a/scripts/sequence_preparation.py
+++ b/scripts/sequence_preparation.py
@@ -10,6 +10,7 @@ import pandas as pd
 from sklearn.preprocessing import MinMaxScaler
 import torch
 from torch.utils.data import Dataset
+import logging
 
 
 class SequencePreparator:
@@ -22,8 +23,8 @@ class SequencePreparator:
     - Train/test splitting while maintaining temporal order
     """
     
-    def __init__(self, seq_length=30, prediction_length=1, 
-                 feature_columns=None, target_column='close'):
+    def __init__(self, seq_length=30, prediction_length=1,
+                 feature_columns=None, target_column='close', strict=False):
         """
         Initialize the sequence preparator.
         
@@ -37,11 +38,14 @@ class SequencePreparator:
             List of feature column names. If None, uses default features
         target_column : str
             Name of the target column
+        strict : bool
+            If True, raise ValueError when expected features are missing
         """
         self.seq_length = seq_length
         self.prediction_length = prediction_length
         self.feature_columns = feature_columns or self._get_default_features()
         self.target_column = target_column
+        self.strict = strict
         self.scaler = MinMaxScaler()
         self.is_fitted = False
         
@@ -63,9 +67,17 @@ class SequencePreparator:
         """
         # Select and validate features
         available_features = []
+        missing_features = []
         for col in self.feature_columns:
             if col in data.columns:
                 available_features.append(col)
+            else:
+                logging.warning("Feature column %s missing from data", col)
+                missing_features.append(col)
+
+        if missing_features and self.strict:
+            raise ValueError(
+                f"Missing required feature columns: {missing_features}")
                 
         if not available_features:
             raise ValueError("No valid feature columns found in data")
@@ -230,7 +242,8 @@ class StockSequenceDataset(Dataset):
             
 
 def prepare_data_for_transformer(data, seq_length=30, prediction_length=1,
-                                train_end_date=None, feature_columns=None):
+                                train_end_date=None, feature_columns=None,
+                                strict=False):
     """
     Convenience function to prepare data for transformer training.
     
@@ -246,6 +259,8 @@ def prepare_data_for_transformer(data, seq_length=30, prediction_length=1,
         End date for training data. If None, uses 80% for training
     feature_columns : list or None
         Feature columns to use
+    strict : bool
+        Whether to enforce presence of all features
         
     Returns:
     --------
@@ -272,7 +287,8 @@ def prepare_data_for_transformer(data, seq_length=30, prediction_length=1,
     preparator = SequencePreparator(
         seq_length=seq_length,
         prediction_length=prediction_length,
-        feature_columns=feature_columns
+        feature_columns=feature_columns,
+        strict=strict
     )
     
     # Prepare sequences

--- a/scripts/transformer_wrapper.py
+++ b/scripts/transformer_wrapper.py
@@ -29,10 +29,11 @@ class TransformerModelWrapper:
     - Model persistence
     """
     
-    def __init__(self, seq_length=30, prediction_length=1, 
+    def __init__(self, seq_length=30, prediction_length=1,
                  n_features=9, d_model=64, n_heads=8, n_layers=2,
                  dropout=0.1, learning_rate=0.001, batch_size=32,
-                 epochs=20, device=None, **kwargs):
+                 epochs=20, device=None, target_column='close',
+                 preparator_strict=False, **kwargs):
         """
         Initialize the transformer wrapper.
         
@@ -60,6 +61,10 @@ class TransformerModelWrapper:
             Number of training epochs
         device : str or None
             Device to use ('cuda' or 'cpu')
+        target_column : str
+            Name of the target column for scaling
+        preparator_strict : bool
+            Whether SequencePreparator should enforce feature presence
         **kwargs : dict
             Additional arguments
         """
@@ -76,12 +81,15 @@ class TransformerModelWrapper:
         self.learning_rate = learning_rate
         self.batch_size = batch_size
         self.epochs = epochs
-        
+
         # Device configuration
         if device is None:
             self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         else:
             self.device = torch.device(device)
+
+        self.target_column = target_column
+        self.preparator_strict = preparator_strict
             
         # Initialize model and components
         self.model = None
@@ -137,7 +145,8 @@ class TransformerModelWrapper:
             seq_length=self.seq_length,
             prediction_length=self.prediction_length,
             feature_columns=self.feature_columns,
-            target_column=self.feature_columns[-1]  # Assume last column is close price
+            target_column=self.target_column,
+            strict=self.preparator_strict
         )
         
         # Prepare sequences
@@ -216,7 +225,11 @@ class TransformerModelWrapper:
             X = pd.DataFrame(X, columns=self.feature_columns)
             
         # Prepare sequences
-        X_seq, _ = self.preparator.transform(X, include_targets=False)
+        try:
+            X_seq, _ = self.preparator.transform(X, include_targets=False)
+        except ValueError:
+            # Not enough data to create sequences
+            return np.full(len(X), 0.5)
         
         # Handle case where we don't have enough data for sequences
         if len(X_seq) == 0:

--- a/tests/test_transformer_module.py
+++ b/tests/test_transformer_module.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pandas as pd
+import torch
+import pytest
+
+from scripts.sequence_preparation import SequencePreparator
+from scripts.transformer_wrapper import TransformerModelWrapper
+
+
+def test_strict_feature_validation():
+    df = pd.DataFrame({'open': [1, 2], 'close': [1, 2]})
+    preparator = SequencePreparator(feature_columns=['open', 'high'], strict=True)
+    with pytest.raises(ValueError):
+        preparator.fit(df)
+
+
+def test_short_sequence_prediction_returns_neutral():
+    df = pd.DataFrame({
+        'open': np.arange(3),
+        'high': np.arange(3),
+        'low': np.arange(3),
+        'close': np.arange(3)
+    })
+    wrapper = TransformerModelWrapper(seq_length=5, n_features=4, target_column='close')
+    wrapper.feature_columns = list(df.columns)
+    wrapper.preparator = SequencePreparator(seq_length=5, feature_columns=wrapper.feature_columns, target_column='close')
+    wrapper.preparator.fit(df)
+    wrapper.model = torch.nn.Identity()
+    wrapper.is_fitted = True
+
+    preds = wrapper.predict(df)
+    assert np.allclose(preds, 0.5)


### PR DESCRIPTION
## Summary
- add strict feature validation to `SequencePreparator`
- allow custom target column and strict mode in `TransformerModelWrapper`
- handle short-sequence prediction failures gracefully
- clarify installation and hybrid strategy example in `README_TRANSFORMER`
- add unit tests for strict validation and short-sequence predictions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c16d2e1188330a2dc502967bfac7f