### PR TITLE
Add requirements-testing file and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ cd DecisionTree
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 pip install -r requirements.txt
+pip install -r requirements-testing.txt  # install test dependencies
 ```
 
 ### Verify Installation

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,5 +1,9 @@
 # Contributing
 
+* Install dependencies first:
+  ```bash
+  pip install -r requirements.txt -r requirements-testing.txt
+  ```
 * Run `pytest -q` before submitting pull requests.
 * Follow standard PEP8 formatting via `flake8`.
 * Open a GitHub issue for significant feature changes.

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -4,7 +4,7 @@ This guide walks you through installing dependencies and training your first tra
 
 1. **Install Requirements**
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.txt -r requirements-testing.txt
    ```
 2. **Prepare Data**
    Place CSV files inside `data/raw/` with columns such as `open`, `high`, `low`, `close`, `volume`.

--- a/docs/integration_guide.md
+++ b/docs/integration_guide.md
@@ -4,7 +4,7 @@ This guide explains how to work with the transformer modules inside the Decision
 
 1. **Install dependencies**
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.txt -r requirements-testing.txt
    ```
 2. **Run tests**
    ```bash

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest>=6.2.5
+pytest-cov>=3.0.0
+flake8>=5.0.4
+schedule>=1.1.0


### PR DESCRIPTION
## Summary
- add `requirements-testing.txt` with `pytest`, `pytest-cov`, `flake8`, and `schedule`
- document how to install testing dependencies in README, contributing guide, integration guide, and getting-started docs

## Testing
- `pip install -r requirements-testing.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_685d7a4733288330b5bbe0216c353fce