### PR TITLE
Add meta-strategy tuning options and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,16 @@ python strategy_runner.py --data data/raw --model random_forest --calibrate --ou
 python strategy_runner.py --data data/raw --model xgboost --output xgb_confidence_test
 ```
 
+#### 3.5 Meta-Strategy Parameter Tuning
+```bash
+# Run meta-strategy with custom tuning parameters
+python strategy_runner.py --data data/raw --model meta_strategy --timeframe 5min \
+    --performance-window 390 --switch-cooldown 78 --output meta_tuned
+
+# Sweep common combinations and save summary CSV
+python meta_strategy_perf_test/param_sweep.py
+```
+
 ### Level 4: Integration & End-to-End Testing
 
 #### 4.1 Complete Workflow Test

--- a/docs/guides/advanced_usage.md
+++ b/docs/guides/advanced_usage.md
@@ -13,3 +13,14 @@ Use `optimize_hyperparameters.py` to run Optuna sweeps.
 
 ## Multi‑GPU Training
 Set the wrapper's `device` argument to a CUDA device id and enable DistributedDataParallel if needed.
+
+## Meta-Strategy Tuning
+Use `strategy_runner.py` with the `meta_strategy` model and adjust the new CLI parameters:
+```bash
+python strategy_runner.py --data data/raw --model meta_strategy --timeframe 5min \
+    --performance-window 390 --switch-cooldown 78 --output meta_run
+```
+For automated sweeps across common parameter combinations, run:
+```bash
+python meta_strategy_perf_test/param_sweep.py
+```

--- a/meta_strategy_perf_test/param_sweep.py
+++ b/meta_strategy_perf_test/param_sweep.py
@@ -1,0 +1,47 @@
+"""Parameter sweep for MetaStrategy performance tuning."""
+import os
+import csv
+from itertools import product
+from strategy_runner import run_single_strategy
+
+PERFORMANCE_WINDOWS = [195, 390, 780]
+SWITCH_COOLDOWNS = [39, 78, 156]
+
+
+def main():
+    data_path = 'data/raw'
+    timeframe = '5min'
+    symbol = 'SPY'
+    results = []
+
+    for pw, sc in product(PERFORMANCE_WINDOWS, SWITCH_COOLDOWNS):
+        output_dir = f'meta_strategy_perf_test/pw_{pw}_sc_{sc}'
+        res = run_single_strategy(
+            data_path=data_path,
+            model_type='meta_strategy',
+            output_dir=output_dir,
+            symbol=symbol,
+            timeframe=timeframe,
+            performance_window=pw,
+            switch_cooldown=sc,
+        )
+        perf = res.get('performance', {})
+        results.append({
+            'performance_window': pw,
+            'switch_cooldown': sc,
+            'sharpe_ratio': perf.get('sharpe_ratio', 0),
+            'max_drawdown': perf.get('max_drawdown', 0),
+            'num_trades': perf.get('num_trades', 0),
+        })
+
+    os.makedirs('meta_strategy_perf_test', exist_ok=True)
+    csv_path = os.path.join('meta_strategy_perf_test', 'sweep_results.csv')
+    with open(csv_path, 'w', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['performance_window', 'switch_cooldown', 'sharpe_ratio', 'max_drawdown', 'num_trades'])
+        writer.writeheader()
+        writer.writerows(results)
+    print(f"Saved results to {csv_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/strategies/meta_strategy.py
+++ b/src/strategies/meta_strategy.py
@@ -48,6 +48,8 @@ class MetaStrategy(BaseStrategy):
         self.selection_method = self.config.get('selection_method', 'performance')
         self.performance_window = self.config.get('performance_window', 100)
         self.switch_cooldown = self.config.get('switch_cooldown', 20)
+        # When True, regime signals can override performance-based selection
+        self.regime_override = self.config.get('regime_override', False)
         
         # Initialize strategy registry
         self.registry = StrategyRegistry()
@@ -73,8 +75,8 @@ class MetaStrategy(BaseStrategy):
         self.current_strategy = self.available_strategies[self.current_strategy_name]
         self.bars_since_switch = 0
         
-        # Regime detection (for regime-based selection)
-        if self.selection_method == 'regime':
+        # Regime detection (for regime-based selection or override)
+        if self.selection_method == 'regime' or self.regime_override:
             self.regime_detector = RegimeDetector(
                 method=self.config.get('regime_method', 'trend_volatility')
             )
@@ -199,7 +201,20 @@ class MetaStrategy(BaseStrategy):
         logger.debug(f"Selecting strategy using method: {self.selection_method}")
         
         if self.selection_method == 'performance':
-            return self._select_by_performance()
+            selected = self._select_by_performance()
+            if self.regime_override and hasattr(self, 'regime_detector'):
+                try:
+                    current_regime = self.regime_detector.get_current_regime()
+                    regime_label = current_regime.get('regime_label', 'neutral')
+                    override = self.regime_map.get(regime_label)
+                    if override and override in self.available_strategies \
+                            and override != selected and regime_label != 'neutral':
+                        logger.info(
+                            f"Regime override: {regime_label} -> {override}")
+                        return override
+                except Exception as e:
+                    logger.error(f"Error in regime override: {e}")
+            return selected
         elif self.selection_method == 'regime':
             return self._select_by_regime(features, dates)
         else:

--- a/strategy_configs.py
+++ b/strategy_configs.py
@@ -344,6 +344,7 @@ STRATEGY_CONFIGS = {
             'weak_downtrend': 'bb_rsi_adx',
             'downtrend': 'tema',
             'strong_downtrend': 'tema'
-        }
+        },
+        'regime_override': True
     }
 }

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -582,9 +582,10 @@ def get_strategy_configs(use_optimized_params=False, include_momentum=False, tim
 
 def run_single_strategy(data_path, model_type='random_forest', output_dir='results',
                        train_end_date=None, symbol='SPY', strategy_type='trend_following',
-                       calibrate=False, use_optimized_params=False, 
+                       calibrate=False, use_optimized_params=False,
                        run_feature_audit_flag=False, audit_model='random_forest',
-                       top_n_features=None, timeframe='daily'):
+                       top_n_features=None, timeframe='daily',
+                       performance_window=None, switch_cooldown=None):
     """
     Run a single strategy with specified parameters.
     
@@ -613,7 +614,11 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         Model type to use for feature importance evaluation
     top_n_features : int, optional
         Number of top features to keep after auditing
-        
+    performance_window : int, optional
+        Lookback window (in bars) for meta-strategy performance tracking
+    switch_cooldown : int, optional
+        Minimum bars between meta-strategy switches
+
     Returns:
     --------
     dict
@@ -708,12 +713,12 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
                 'primary_timeframe': '5T'  # 5-minute default for Quod
             })
         elif model_type == 'meta_strategy':
-            config.update({
-                'selection_method': 'performance',
-                'performance_window': 100,
-                'switch_cooldown': 20,
-                'strategies': ['quod', 'tema', 'bb_rsi_adx']
-            })
+            config = STRATEGY_CONFIGS.get('meta_strategy', {}).copy()
+            if performance_window is not None:
+                config['performance_window'] = performance_window
+            if switch_cooldown is not None:
+                config['switch_cooldown'] = switch_cooldown
+            config.setdefault('strategies', ['quod', 'tema', 'bb_rsi_adx'])
             # Dynamically import and register meta-strategy if needed
             if 'meta_strategy' not in StrategyRegistry.list_strategies():
                 from src.strategies.meta_strategy import MetaStrategy
@@ -933,10 +938,15 @@ def parse_arguments():
     parser.add_argument('--include-momentum', action='store_true',
                         help='Include momentum strategies (BB-RSI-ADX, TEMA, Quod) in comparison mode')
     
-    parser.add_argument('--timeframe', 
-                        choices=['daily', '5min'], 
+    parser.add_argument('--timeframe',
+                        choices=['daily', '5min'],
                         default='daily',
                         help='Data timeframe to use (default: daily)')
+
+    parser.add_argument('--performance-window', type=int, default=None,
+                        help='Performance window for meta-strategy (bars)')
+    parser.add_argument('--switch-cooldown', type=int, default=None,
+                        help='Switch cooldown for meta-strategy (bars)')
     
     return parser.parse_args()
 
@@ -969,7 +979,9 @@ def main():
             run_feature_audit_flag=args.feature_audit,
             audit_model=args.audit_model,
             top_n_features=args.top_features,
-            timeframe=args.timeframe
+            timeframe=args.timeframe,
+            performance_window=args.performance_window,
+            switch_cooldown=args.switch_cooldown
         )
     else:  # compare mode
         run_strategy_comparison(

--- a/tests/test_meta_strategy_logic.py
+++ b/tests/test_meta_strategy_logic.py
@@ -115,3 +115,51 @@ def test_meta_strategy_regime_selection(monkeypatch, dummy_data):
 
     selected = meta._select_strategy(dummy_data, dummy_data.index)
     assert selected == 's2'
+
+
+def test_meta_strategy_regime_override(monkeypatch, dummy_data):
+    sharpe_map = {
+        's1': {'sharpe_ratio': 1.0, 'insufficient_data': False},
+        's2': {'sharpe_ratio': 0.5, 'insufficient_data': False},
+    }
+
+    monkeypatch.setattr(StrategyRegistry, 'create_strategy', classmethod(lambda cls, name, config=None: DummyStrategy(name)))
+    monkeypatch.setattr(StrategyRegistry, 'get_performance_stats', classmethod(lambda cls, name, window=100: sharpe_map[name]))
+
+    config = {
+        'strategies': ['s1', 's2'],
+        'selection_method': 'performance',
+        'regime_override': True,
+        'regime_map': {'bull': 's2', 'neutral': 's1'},
+    }
+    meta = MetaStrategy(config)
+
+    monkeypatch.setattr(meta.regime_detector, 'get_current_regime', lambda: {'regime_label': 'bull'})
+
+    selected = meta._select_strategy(dummy_data, dummy_data.index)
+    assert selected == 's2'
+
+
+def test_meta_strategy_records_switch(monkeypatch, dummy_data):
+    sharpe_map = {
+        's1': {'sharpe_ratio': 0.0, 'insufficient_data': False},
+        's2': {'sharpe_ratio': 1.0, 'insufficient_data': False},
+    }
+
+    monkeypatch.setattr(StrategyRegistry, 'create_strategy', classmethod(lambda cls, name, config=None: DummyStrategy(name)))
+    monkeypatch.setattr(StrategyRegistry, 'get_performance_stats', classmethod(lambda cls, name, window=100: sharpe_map[name]))
+
+    config = {
+        'strategies': ['s1', 's2'],
+        'selection_method': 'performance',
+        'performance_window': 10,
+        'switch_cooldown': 0,
+    }
+    meta = MetaStrategy(config)
+
+    features = dummy_data
+    dates = dummy_data.index
+    predictions = np.zeros(len(features))
+
+    meta.generate_signals(features, predictions, dates)
+    assert meta.selection_history[-1]['strategy'] == 's2'


### PR DESCRIPTION
## Summary
- Allow meta-strategy to override performance-based selection with regime signals
- Expose `--performance-window` and `--switch-cooldown` CLI arguments and default config
- Provide parameter sweep script and document meta-strategy tuning

## Testing
- `pytest tests/test_meta_strategy_logic.py -q --no-cov`
- `python strategy_runner.py --data data/raw --model meta_strategy --mode single --output meta_strategy_run --timeframe 5min --performance-window 390 --switch-cooldown 78` *(fails: FileNotFoundError: 5-minute data files not found for SPY)*

------
https://chatgpt.com/codex/tasks/task_e_6894cd0219988330b83d815379888b32