### PR TITLE
Add hybrid ML–momentum strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The system has evolved into a sophisticated trading platform with the following 
 ✅ **Hyperparameter Optimization**: Automated optimization with Optuna  
 ✅ **Feature Engineering**: Advanced feature auditing and pruning capabilities  
 ✅ **Market Regime Detection**: Multi-method regime identification and adaptation  
-✅ **Performance Analysis**: Comprehensive backtesting and visualization  
-✅ **Modular Architecture**: Engine-based design with clear separation of concerns  
+✅ **Performance Analysis**: Comprehensive backtesting and visualization
+✅ **Modular Architecture**: Engine-based design with clear separation of concerns
+✅ **Hybrid ML + Momentum Strategy**: Combine ML predictions with momentum signals
 
 ### Success Metrics
 - **CAGR/Max Drawdown ratio** > 0.40 (vs S&P 500's ~0.18)
@@ -502,3 +503,11 @@ For live trading (Phase 3), configure IBKR:
 ---
 
 **Note**: This is an active development project currently in Phase 1.5 of the v0.2 roadmap. Critical issues as of 2025-06-05 have been resolved. For issues or contributions, see the development documentation in the main strategy file.
+### Hybrid ML + Momentum Example
+
+Run the default XGBoost + TEMA hybrid on 5‑minute data:
+
+```bash
+python strategy_runner.py --data data/raw --model hybrid_momentum --timeframe 5min --output hybrid_run
+```
+

--- a/docs/guides/advanced_usage.md
+++ b/docs/guides/advanced_usage.md
@@ -31,3 +31,15 @@ For automated sweeps across common parameter combinations, run:
 ```bash
 python meta_strategy_perf_test/param_sweep.py
 ```
+
+## Hybrid ML + Momentum Strategy
+
+The platform can blend machine learning predictions with momentum signals.
+The default configuration pairs an XGBoost model with the TEMA strategy.
+
+```bash
+python strategy_runner.py --data data/raw --model hybrid_momentum --timeframe 5min --output hybrid_run
+```
+
+`agree_only` and `weights` parameters can be adjusted in `strategy_configs.py`
+to experiment with different fusion modes.

--- a/src/strategies/__init__.py
+++ b/src/strategies/__init__.py
@@ -7,5 +7,11 @@ This module contains various trading strategy implementations.
 from .base_strategy import BaseStrategy
 from .trend_following import TrendFollowingStrategy
 from .regime_adaptive_strategy import RegimeAdaptiveStrategy
+from .hybrid_momentum_strategy import HybridMomentumMLStrategy
 
-__all__ = ["BaseStrategy", "TrendFollowingStrategy", "RegimeAdaptiveStrategy"]
+__all__ = [
+    "BaseStrategy",
+    "TrendFollowingStrategy",
+    "RegimeAdaptiveStrategy",
+    "HybridMomentumMLStrategy",
+]

--- a/src/strategies/hybrid_momentum_strategy.py
+++ b/src/strategies/hybrid_momentum_strategy.py
@@ -1,0 +1,161 @@
+"""Hybrid strategy combining ML model predictions with momentum strategy signals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+import numpy as np
+import pandas as pd
+
+from .base_strategy import BaseStrategy
+from .trend_following import TrendFollowingStrategy
+
+
+@dataclass
+class HybridComponents:
+    """Container for hybrid strategy components."""
+    ml_strategy: BaseStrategy
+    momentum_strategy: BaseStrategy
+
+
+class HybridMomentumMLStrategy(BaseStrategy):
+    """Strategy that fuses ML predictions with momentum signals.
+
+    Parameters are supplied via ``initialize`` using a configuration dictionary
+    containing:
+
+    ``ml_model_type``: Name of the ML model (e.g. ``"xgboost"``)
+    ``ml_model_params``: Parameters forwarded to :class:`TrendFollowingStrategy`
+    ``momentum_strategy``: Name of momentum strategy registered in
+        :class:`StrategyRegistry`
+    ``agree_only``: If True, take trades only when both components agree
+    ``weights``: Tuple of (ml_weight, momentum_weight) used when
+        ``agree_only`` is False
+    """
+
+    def __init__(self,
+                 ml_strategy: Optional[BaseStrategy] = None,
+                 momentum_strategy: Optional[BaseStrategy] = None) -> None:
+        super().__init__()
+        self.components = HybridComponents(ml_strategy, momentum_strategy)
+        self.agree_only: bool = True
+        self.weights: Tuple[float, float] = (0.5, 0.5)
+        self.is_trained: bool = False
+
+    # ------------------------------------------------------------------
+    def initialize(self, config: Dict) -> None:  # type: ignore[override]
+        """Initialize hybrid strategy with configuration."""
+        super().initialize(config)
+        self.config = config
+        self.agree_only = config.get("agree_only", True)
+        self.weights = tuple(config.get("weights", (0.5, 0.5)))  # type: ignore
+
+        # Create ML strategy if not supplied
+        if self.components.ml_strategy is None:
+            ml_model_type = config.get("ml_model_type", "xgboost")
+            ml_params = config.get("ml_model_params", {})
+            ml_cfg = {
+                "name": f"{ml_model_type.title()} Hybrid", 
+                "model_type": ml_model_type,
+                "model_params": ml_params,
+                "timeframe": config.get("timeframe", "5min"),
+                "use_adaptive_thresholds": config.get("use_adaptive_thresholds", "auto"),
+            }
+            ml_strategy = TrendFollowingStrategy()
+            ml_strategy.initialize(ml_cfg)
+            self.components.ml_strategy = ml_strategy
+
+        # Create momentum strategy if not supplied
+        if self.components.momentum_strategy is None:
+            from .strategy_registry import StrategyRegistry
+
+            mom_name = config.get("momentum_strategy", "tema")
+            mom_cfg = {
+                "name": mom_name.upper(),
+                "symbol": config.get("symbol", "SPY"),
+                "primary_timeframe": config.get("timeframe", "5min"),
+            }
+            momentum_strategy = StrategyRegistry.get_strategy(mom_name, mom_cfg)
+            self.components.momentum_strategy = momentum_strategy
+
+    # ------------------------------------------------------------------
+    def train(self, data: pd.DataFrame) -> None:  # type: ignore[override]
+        """Train underlying ML strategy."""
+        self.components.ml_strategy.train(data)
+        self.is_trained = True
+
+    # ------------------------------------------------------------------
+    def predict(self, test_data: pd.DataFrame):  # type: ignore[override]
+        """Generate hybrid signals for ``test_data``.
+
+        Returns
+        -------
+        tuple
+            (signals_dataframe, combined_probabilities)
+        """
+        if not self.is_trained:
+            raise ValueError("Hybrid strategy must be trained before prediction.")
+
+        ml_strategy = self.components.ml_strategy
+        momentum_strategy = self.components.momentum_strategy
+
+        ml_signals, ml_pred = ml_strategy.predict(test_data)
+
+        # Momentum strategy is rule-based – generate its signals directly
+        mom_features, _, mom_dates = momentum_strategy.generate_features(test_data)
+        mom_signals = momentum_strategy.generate_signals(mom_features, None, mom_dates)
+
+        combined_df = pd.DataFrame(index=ml_signals.index.union(mom_signals.index))
+        combined_df["ml_signal"] = ml_signals["signal"].reindex(combined_df.index).fillna(0)
+        combined_df["ml_prob"] = pd.Series(ml_pred, index=ml_signals.index).reindex(combined_df.index).fillna(0.5)
+        combined_df["mom_signal"] = mom_signals["signal"].reindex(combined_df.index).fillna(0)
+
+        if self.agree_only:
+            combined_df["combined_signal"] = np.where(
+                (combined_df["ml_signal"] == 1) & (combined_df["mom_signal"] == 1), 1,
+                np.where(
+                    (combined_df["ml_signal"] == -1) & (combined_df["mom_signal"] == -1),
+                    -1,
+                    0,
+                ),
+            )
+            combined_df["combined_prob"] = np.where(
+                combined_df["combined_signal"] == 1,
+                1.0,
+                np.where(combined_df["combined_signal"] == -1, 0.0, 0.5),
+            )
+        else:
+            mom_prob = (combined_df["mom_signal"] + 1) / 2
+            combined_prob = (
+                self.weights[0] * combined_df["ml_prob"] +
+                self.weights[1] * mom_prob
+            ).clip(0, 1)
+            probs = combined_prob.values
+            combined_df["combined_prob"] = combined_prob
+            combined_df["combined_signal"] = [
+                self._prob_to_signal(p, probs) for p in probs
+            ]
+
+        signals = combined_df[["combined_signal"]].rename(columns={"combined_signal": "signal"})
+        return signals, combined_df["combined_prob"].values
+
+    # ------------------------------------------------------------------
+    def generate_features(self, data):  # type: ignore[override]
+        """Delegate feature generation to the ML strategy."""
+        return self.components.ml_strategy.generate_features(data)
+
+    # ------------------------------------------------------------------
+    def generate_signals(self, features, predictions, dates):  # type: ignore[override]
+        """Not used directly. Use :meth:`predict` instead."""
+        raise NotImplementedError("HybridMomentumMLStrategy uses predict() for signal generation")
+
+    # ------------------------------------------------------------------
+    def backtest(self, data, train_data=None, test_data=None, timeframe='daily'):  # type: ignore[override]
+        """Simple backtest wrapper for compatibility."""
+        if train_data is None or test_data is None:
+            train_size = int(len(data) * 0.7)
+            train_data = data.iloc[:train_size]
+            test_data = data.iloc[train_size:]
+        self.train(train_data)
+        signals, _ = self.predict(test_data)
+        return {'signals': signals}

--- a/src/strategies/strategy_registry.py
+++ b/src/strategies/strategy_registry.py
@@ -12,6 +12,7 @@ from src.strategies.base_strategy import BaseStrategy
 from src.strategies.trend_following import TrendFollowingStrategy
 from src.strategies.regime_adaptive_strategy import RegimeAdaptiveStrategy
 from src.strategies.adapters import BBRSIADXAdapter, TEMAAdapter, QuodAdapter
+from src.strategies.hybrid_momentum_strategy import HybridMomentumMLStrategy
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -33,6 +34,7 @@ class StrategyRegistry:
         'bb_rsi_adx': BBRSIADXAdapter,
         'tema': TEMAAdapter,
         'quod': QuodAdapter,
+        'hybrid_momentum': HybridMomentumMLStrategy,
     }
     
     # Aliases for backward compatibility and convenience

--- a/strategy_configs.py
+++ b/strategy_configs.py
@@ -339,6 +339,17 @@ TEMA_5MIN_CONFIG = {
     'allow_same_bar_exit': True
 }
 
+HYBRID_XGB_TEMA_5MIN_CONFIG = {
+    'name': 'Hybrid XGBoost+TEMA (5min)',
+    'model_type': 'hybrid_momentum',
+    'ml_model_type': 'xgboost',
+    'ml_model_params': XGBOOST_5MIN_CONFIG['model_params'],
+    'momentum_strategy': 'tema',
+    'agree_only': True,
+    'weights': (0.3, 0.7),
+    'timeframe': '5min'
+}
+
 # All strategy configurations
 STRATEGY_CONFIGS = {
     'decision_tree': DECISION_TREE_CONFIG,
@@ -377,6 +388,7 @@ STRATEGY_CONFIGS = {
     # 5-minute momentum strategies
     'bb_rsi_adx_5min': BB_RSI_ADX_5MIN_CONFIG,
     'tema_5min': TEMA_5MIN_CONFIG,
+    'hybrid_xgb_tema_5min': HYBRID_XGB_TEMA_5MIN_CONFIG,
     # Meta-strategy configuration
     'meta_strategy': {
         'name': 'meta_strategy',

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -669,6 +669,9 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         # For momentum strategies, use the model type as the strategy type
         strategy_type = model_type
         config_key = None  # Will create custom config below
+    elif model_type == 'hybrid_momentum':
+        strategy_type = 'hybrid_momentum'
+        config_key = 'hybrid_xgb_tema_5min'
     else:
         # Select appropriate configuration from STRATEGY_CONFIGS for ML models
         config_key = None
@@ -912,7 +915,7 @@ def parse_arguments():
     
     parser.add_argument('--model', type=str,
                         choices=['decision_tree', 'random_forest', 'xgboost', 'stacking', 'transformer', 'hybrid',
-                                 'bb_rsi_adx', 'tema', 'quod', 'meta_strategy'],
+                                 'bb_rsi_adx', 'tema', 'quod', 'meta_strategy', 'hybrid_momentum'],
                         default='random_forest',
                         help='Model type for single mode (default: random_forest)')
     

--- a/tests/test_hybrid_momentum_strategy.py
+++ b/tests/test_hybrid_momentum_strategy.py
@@ -1,0 +1,63 @@
+import pandas as pd
+import numpy as np
+
+from src.strategies.hybrid_momentum_strategy import HybridMomentumMLStrategy
+from src.strategies.base_strategy import BaseStrategy
+
+
+class DummyMLStrategy(BaseStrategy):
+    def initialize(self, config):
+        super().initialize(config)
+    def generate_features(self, data):
+        return data, None, data.index
+    def generate_signals(self, features, predictions, dates):
+        return pd.DataFrame({'signal': [1, -1, 1]}, index=dates)
+    def train(self, data):
+        pass
+    def predict(self, data):
+        idx = data.index
+        signals = pd.DataFrame({'signal': [1, -1, 1]}, index=idx)
+        preds = np.array([0.8, 0.2, 0.6])
+        return signals, preds
+    def backtest(self, data):
+        pass
+
+
+class DummyMomentumStrategy(BaseStrategy):
+    def initialize(self, config):
+        super().initialize(config)
+    def generate_features(self, data):
+        return data, None, data.index
+    def generate_signals(self, features, predictions, dates):
+        signals = pd.DataFrame({'signal': [1, -1, 0]}, index=dates)
+        return signals
+    def train(self, data):
+        pass
+    def predict(self, data):
+        return self.generate_signals(data, None, data.index)
+    def backtest(self, data):
+        pass
+
+
+def test_agreement_only_mode():
+    data = pd.DataFrame(index=pd.date_range('2023-01-01', periods=3, freq='D'))
+    ml = DummyMLStrategy()
+    mom = DummyMomentumStrategy()
+    strat = HybridMomentumMLStrategy(ml_strategy=ml, momentum_strategy=mom)
+    strat.initialize({'agree_only': True})
+    strat.is_trained = True
+    signals, probs = strat.predict(data)
+    assert signals['signal'].tolist() == [1, -1, 0]
+    assert np.allclose(probs, [1.0, 0.0, 0.5])
+
+
+def test_weighted_fusion_mode():
+    data = pd.DataFrame(index=pd.date_range('2023-01-01', periods=3, freq='D'))
+    ml = DummyMLStrategy()
+    mom = DummyMomentumStrategy()
+    strat = HybridMomentumMLStrategy(ml_strategy=ml, momentum_strategy=mom)
+    strat.initialize({'agree_only': False, 'weights': (0.3, 0.7)})
+    strat.is_trained = True
+    signals, probs = strat.predict(data)
+    assert signals['signal'].tolist() == [1, -1, 0]
+    assert np.allclose(probs, [0.94, 0.06, 0.53])


### PR DESCRIPTION
## Summary
- Implement `HybridMomentumMLStrategy` to combine ML predictions with momentum signals
- Register hybrid strategy and configuration, add CLI support and usage docs
- Add unit tests for agreement and weighted fusion modes

## Testing
- `pytest tests/test_hybrid_momentum_strategy.py -q --no-cov`
- `pytest tests/test_momentum_adapters.py -q --no-cov`
- `python strategy_runner.py --data data/raw --model hybrid_momentum --timeframe 5min --output hybrid_run` *(fails: FileNotFoundError: 5-minute data files not found for SPY)*

------
https://chatgpt.com/codex/tasks/task_e_6894f41a7af08330a4f2d6888960ed13