### PR TITLE
Sharpe-optimized hyperparameters with multi-timeframe signal ensemble

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ The system has evolved into a sophisticated trading platform with the following 
 
 ✅ **Multi-Model Support**: Decision Tree, Random Forest, XGBoost, and Stacking ensembles  
 ✅ **Strategy Framework**: TrendFollowing and RegimeAdaptive strategies  
-✅ **Hyperparameter Optimization**: Automated optimization with Optuna  
-✅ **Feature Engineering**: Advanced feature auditing and pruning capabilities  
+✅ **Hyperparameter Optimization**: Automated optimization with Optuna
+✅ **Sharpe-Based Tuning**: Hyperparameter sweeps maximize trading Sharpe ratio
+✅ **Feature Engineering**: Advanced feature auditing and pruning capabilities
 ✅ **Market Regime Detection**: Multi-method regime identification and adaptation  
 ✅ **Performance Analysis**: Comprehensive backtesting and visualization
 ✅ **Modular Architecture**: Engine-based design with clear separation of concerns
 ✅ **Hybrid ML + Momentum Strategy**: Combine ML predictions with momentum signals
+✅ **Multi-Timeframe Ensemble**: Aggregate signals across 5min–daily horizons
 
 ### Success Metrics
 - **CAGR/Max Drawdown ratio** > 0.40 (vs S&P 500's ~0.18)

--- a/docs/guides/advanced_usage.md
+++ b/docs/guides/advanced_usage.md
@@ -9,7 +9,10 @@ model = ModelFactory.create_model('transformer', d_model=128, n_heads=4, n_layer
 ```
 
 ## Hyperparameter Tuning
-Use `optimize_hyperparameters.py` to run Optuna sweeps.
+Use `optimize_hyperparameters.py` to run Optuna sweeps. The optimizer now
+evaluates candidate parameters by backtesting and maximizing Sharpe ratio,
+ensuring tuned models improve trading performance rather than just
+classification accuracy.
 
 ## Multi‑GPU Training
 Set the wrapper's `device` argument to a CUDA device id and enable DistributedDataParallel if needed.
@@ -43,3 +46,15 @@ python strategy_runner.py --data data/raw --model hybrid_momentum --timeframe 5m
 
 `agree_only` and `weights` parameters can be adjusted in `strategy_configs.py`
 to experiment with different fusion modes.
+
+## Multi-Timeframe Signal Ensemble
+
+Strategies can be wrapped in `MultiTimeframeStrategy` to aggregate signals
+across multiple resolutions (e.g., 5min, 15min, 1h, daily). Add a
+`multi_timeframe` configuration in `strategy_configs.py` and run via
+
+```bash
+python strategy_runner.py --data data/raw --model multi_tf_tema --timeframe 5min
+```
+Signals from each timeframe are averaged (or majority voted) to produce a
+single trade decision, improving robustness across market regimes.

--- a/optimize_hyperparameters.py
+++ b/optimize_hyperparameters.py
@@ -155,15 +155,16 @@ def prepare_features_and_target(df, lookback_period=None):
     # Remove rows with NaN values
     df = df.dropna()
     
-    # Extract features and target
+    # Extract features, target, and aligned price series for backtesting
     X = df[features]
     y = df['target']
-    
+    prices = df['close'].copy()
+
     print(f"Features prepared. X shape: {X.shape}, y shape: {y.shape}")
     print(f"Features: {features}")
     print(f"Target distribution: {y.value_counts(normalize=True)}")
-    
-    return X, y
+
+    return X, y, prices
 
 def detect_regimes(df, method='trend_volatility'):
     """
@@ -216,8 +217,8 @@ def optimize_hyperparameters(args):
     # Load data
     df = load_data(args.data, args.symbol)
     
-    # Prepare features and target
-    X, y = prepare_features_and_target(df, args.lookback)
+    # Prepare features, target, and price series
+    X, y, prices = prepare_features_and_target(df, args.lookback)
     
     # Create hyperparameter manager
     hyperparam_manager = HyperparameterManager(args.output)
@@ -240,6 +241,7 @@ def optimize_hyperparameters(args):
             regime_models = hyperparam_manager.get_regime_specific_models(
                 X=X,
                 y=y,
+                prices=prices,
                 model_type=model_type,
                 regimes=regimes,
                 force_optimization=True,
@@ -270,6 +272,7 @@ def optimize_hyperparameters(args):
                 model_type=model_type,
                 X=X,
                 y=y,
+                prices=prices,
                 n_trials=args.trials
             )
             

--- a/src/models/hyperparameter_manager.py
+++ b/src/models/hyperparameter_manager.py
@@ -254,7 +254,7 @@ class HyperparameterManager:
         with open(metadata_path, 'w') as f:
             json.dump(metadata, f, indent=2)
     
-    def optimize_hyperparameters(self, model_type, X, y, n_trials=None, regime=None):
+    def optimize_hyperparameters(self, model_type, X, y, prices, n_trials=None, regime=None):
         """
         Optimize hyperparameters for a model type.
         
@@ -292,6 +292,7 @@ class HyperparameterManager:
             model_type=model_type,
             X=X,
             y=y,
+            prices=prices,
             n_trials=n_trials,
             n_splits=config.TIMESERIES_CV_SPLITS,
             random_state=config.RANDOM_STATE
@@ -302,7 +303,7 @@ class HyperparameterManager:
         
         return best_params
     
-    def create_optimized_model(self, model_type, X=None, y=None, regime=None, 
+    def create_optimized_model(self, model_type, X=None, y=None, prices=None, regime=None,
                             force_optimization=False, n_trials=None):
         """
         Create a model with optimized hyperparameters.
@@ -331,8 +332,8 @@ class HyperparameterManager:
         from .model_factory import ModelFactory
         
         # If forcing optimization and data is provided, optimize
-        if force_optimization and X is not None and y is not None:
-            best_params = self.optimize_hyperparameters(model_type, X, y, n_trials, regime)
+        if force_optimization and X is not None and y is not None and prices is not None:
+            best_params = self.optimize_hyperparameters(model_type, X, y, prices, n_trials, regime)
         else:
             # Otherwise, load best parameters
             best_params = self.get_best_params(model_type, regime)
@@ -340,7 +341,7 @@ class HyperparameterManager:
         # Create model with best parameters
         return ModelFactory.create_model(model_type, **best_params)
     
-    def get_regime_specific_models(self, X, y, model_type, regimes, 
+    def get_regime_specific_models(self, X, y, prices, model_type, regimes,
                                     force_optimization=False, n_trials=None):
         """
         Create regime-specific models with optimized hyperparameters.
@@ -385,10 +386,11 @@ class HyperparameterManager:
             # Extract data for this regime using positional indices
             X_regime = X.iloc[regime_indices]
             y_regime = y.iloc[regime_indices]
+            price_regime = prices.iloc[regime_indices]
             
             # Create optimized model for this regime
             regime_models[regime] = self.create_optimized_model(
-                model_type, X_regime, y_regime, regime, 
+                model_type, X_regime, y_regime, price_regime, regime,
                 force_optimization, n_trials
             )
             

--- a/src/models/hyperparameter_optimization.py
+++ b/src/models/hyperparameter_optimization.py
@@ -15,13 +15,28 @@ import numpy as np
 import pandas as pd
 import config
 import warnings
-from sklearn.model_selection import TimeSeriesSplit, cross_val_score
+from sklearn.model_selection import TimeSeriesSplit
 from sklearn.preprocessing import StandardScaler
 import optuna
 from optuna.samplers import TPESampler
-import config
+from src.backtesting.engine import BacktestEngine
 
-def optimize_decision_tree(X, y, n_trials=100, n_splits=5, random_state=42):
+def _sharpe_from_predictions(preds, price_series):
+    """Convert predictions to signals and compute Sharpe ratio via backtest."""
+    signals = pd.DataFrame({
+        'date': price_series.index,
+        'symbol': 'SPY',
+        'signal': np.where(preds > 0, 1, -1)
+    })
+    engine = BacktestEngine(initial_capital=config.INITIAL_CAPITAL)
+    data = pd.DataFrame({'close': price_series.values}, index=price_series.index)
+    results = engine.run_backtest(signals, {'SPY': data})
+    trades = results.get('trades', pd.DataFrame())
+    if trades.empty:
+        return -np.inf
+    return results['performance'].get('sharpe_ratio', -np.inf)
+
+def optimize_decision_tree(X, y, prices, n_trials=100, n_splits=5, random_state=42):
     """
     Optimize hyperparameters for Decision Tree model using Optuna.
     
@@ -70,17 +85,17 @@ def optimize_decision_tree(X, y, n_trials=100, n_splits=5, random_state=42):
         
         # Use TimeSeriesSplit for cross-validation
         tscv = TimeSeriesSplit(n_splits=n_splits)
-        
-        # Evaluate model with cross-validation
-        scores = cross_val_score(
-            pipeline, X, y, 
-            cv=tscv, 
-            scoring='accuracy',
-            n_jobs=-1
-        )
-        
-        # Return mean score
-        return scores.mean()
+        sharpe_scores = []
+        for train_idx, test_idx in tscv.split(X):
+            X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+            y_train = y.iloc[train_idx]
+            price_test = prices.iloc[test_idx]
+
+            pipeline.fit(X_train, y_train)
+            preds = pipeline.predict(X_test)
+            sharpe_scores.append(_sharpe_from_predictions(preds, price_test))
+
+        return float(np.nanmean(sharpe_scores))
     
     # Create study with TPE sampler
     study = optuna.create_study(
@@ -94,7 +109,7 @@ def optimize_decision_tree(X, y, n_trials=100, n_splits=5, random_state=42):
     # Return best hyperparameters
     return study.best_params
 
-def optimize_random_forest(X, y, n_trials=100, n_splits=5, random_state=42):
+def optimize_random_forest(X, y, prices, n_trials=100, n_splits=5, random_state=42):
     """
     Optimize hyperparameters for Random Forest model using Optuna.
     
@@ -142,20 +157,20 @@ def optimize_random_forest(X, y, n_trials=100, n_splits=5, random_state=42):
         
         # Create pipeline with scaling
         pipeline = make_pipeline(StandardScaler(), model)
-        
+
         # Use TimeSeriesSplit for cross-validation
         tscv = TimeSeriesSplit(n_splits=n_splits)
-        
-        # Evaluate model with cross-validation
-        scores = cross_val_score(
-            pipeline, X, y, 
-            cv=tscv, 
-            scoring='accuracy',
-            n_jobs=-1
-        )
-        
-        # Return mean score
-        return scores.mean()
+        sharpe_scores = []
+        for train_idx, test_idx in tscv.split(X):
+            X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+            y_train = y.iloc[train_idx]
+            price_test = prices.iloc[test_idx]
+
+            pipeline.fit(X_train, y_train)
+            preds = pipeline.predict(X_test)
+            sharpe_scores.append(_sharpe_from_predictions(preds, price_test))
+
+        return float(np.nanmean(sharpe_scores))
     
     # Create study with TPE sampler
     study = optuna.create_study(
@@ -169,118 +184,48 @@ def optimize_random_forest(X, y, n_trials=100, n_splits=5, random_state=42):
     # Return best hyperparameters
     return study.best_params
 
-def optimize_xgboost(X, y, n_trials=100, n_splits=5, random_state=42):
-    """
-    Optimize hyperparameters for XGBoost model using Optuna.
-    
-    This function now works with the simplified XGBoost implementation
-    that uses standard XGBClassifier without focal loss complexity.
-    
-    Parameters:
-    -----------
-    X : pd.DataFrame
-        Feature matrix
-    y : pd.Series
-        Target values
-    n_trials : int
-        Number of optimization trials (default: 100)
-    n_splits : int
-        Number of splits for TimeSeriesSplit (default: 5)
-    random_state : int
-        Random seed for reproducibility (default: 42)
-        
-    Returns:
-    --------
-    dict
-        Best hyperparameters
-    """
-    # Define the objective function for Optuna
+def optimize_xgboost(X, y, prices, n_trials=100, n_splits=5, random_state=42):
+    """Optimize hyperparameters for XGBoost using Sharpe ratio."""
+
     def objective(trial):
-        try:
-            # Import required modules
-            from ..models.xgboost_model import XGBoostModel
-            
-            # Define hyperparameters to optimize (simplified - no focal loss)
-            params = {
-                'n_estimators': trial.suggest_int('n_estimators', 50, 500),
-                'max_depth': trial.suggest_int('max_depth', 3, 12),
-                'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True),
-                'subsample': trial.suggest_float('subsample', 0.6, 1.0),
-                'colsample_bytree': trial.suggest_float('colsample_bytree', 0.6, 1.0),
-                'gamma': trial.suggest_float('gamma', 0, 5),
-                'min_child_weight': trial.suggest_int('min_child_weight', 1, 10),
-                'reg_alpha': trial.suggest_float('reg_alpha', 0, 5),
-                'reg_lambda': trial.suggest_float('reg_lambda', 0, 5),
-                'scale_pos_weight': trial.suggest_float('scale_pos_weight', 1, 10),
-                'class_weight': trial.suggest_categorical('class_weight', ['balanced', None])
-            }
-            
-            # Create custom evaluation function using the simplified XGBoostModel
-            def custom_cv_score_with_model(X, y, cv):
-                scores = []
-                for train_idx, test_idx in cv.split(X):
-                    X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
-                    y_train, y_test = y.iloc[train_idx], y.iloc[test_idx]
-                    
-                    # Create XGBoostModel with suggested hyperparameters
-                    model = XGBoostModel(
-                        n_estimators=params['n_estimators'],
-                        max_depth=params['max_depth'],
-                        learning_rate=params['learning_rate'],
-                        subsample=params['subsample'],
-                        colsample_bytree=params['colsample_bytree'],
-                        gamma=params['gamma'],
-                        min_child_weight=params['min_child_weight'],
-                        reg_alpha=params['reg_alpha'],
-                        reg_lambda=params['reg_lambda'],
-                        scale_pos_weight=params['scale_pos_weight'],
-                        random_state=random_state,
-                        class_weight=params['class_weight']
-                    )
-                    
-                    # Train the model using the same method as in production
-                    model.train(X_train, y_train)
-                    
-                    # Get predictions using the same method as in production
-                    y_pred_proba = model.predict(X_test)
-                    
-                    # Convert to binary predictions using threshold 0.5
-                    y_pred = (y_pred_proba > 0.5).astype(int)
-                    
-                    # Calculate accuracy
-                    score = (y_pred == y_test).mean()
-                    scores.append(score)
-                
-                return np.mean(scores)
-            
-            # Use TimeSeriesSplit for cross-validation
-            tscv = TimeSeriesSplit(n_splits=n_splits)
-            
-            # Perform custom cross-validation using the actual XGBoostModel
-            score = custom_cv_score_with_model(X, y, tscv)
-            
-            # Return the mean score
-            return score
-            
-        except ImportError as e:
-            # If XGBoost is not available, return a bad score
-            print(f"Import error in XGBoost optimization: {e}")
-            return 0.0
-        except Exception as e:
-            # Log any errors for debugging
-            print(f"Error in XGBoost optimization: {e}")
-            return 0.0
-    
-    # Create study with TPE sampler
-    study = optuna.create_study(
-        direction='maximize',
-        sampler=TPESampler(seed=random_state)
-    )
-    
-    # Optimize hyperparameters
+        from xgboost import XGBClassifier
+
+        params = {
+            'n_estimators': trial.suggest_int('n_estimators', 50, 500),
+            'max_depth': trial.suggest_int('max_depth', 3, 12),
+            'learning_rate': trial.suggest_float('learning_rate', 0.01, 0.3, log=True),
+            'subsample': trial.suggest_float('subsample', 0.6, 1.0),
+            'colsample_bytree': trial.suggest_float('colsample_bytree', 0.6, 1.0),
+            'gamma': trial.suggest_float('gamma', 0, 5),
+            'min_child_weight': trial.suggest_int('min_child_weight', 1, 10),
+            'reg_alpha': trial.suggest_float('reg_alpha', 0, 5),
+            'reg_lambda': trial.suggest_float('reg_lambda', 0, 5),
+            'scale_pos_weight': trial.suggest_float('scale_pos_weight', 1, 10)
+        }
+
+        model = XGBClassifier(
+            objective='binary:logistic',
+            use_label_encoder=False,
+            eval_metric='logloss',
+            random_state=random_state,
+            **params
+        )
+
+        tscv = TimeSeriesSplit(n_splits=n_splits)
+        sharpe_scores = []
+        for train_idx, test_idx in tscv.split(X):
+            X_train, X_test = X.iloc[train_idx], X.iloc[test_idx]
+            y_train = y.iloc[train_idx]
+            price_test = prices.iloc[test_idx]
+
+            model.fit(X_train, y_train)
+            preds = model.predict(X_test)
+            sharpe_scores.append(_sharpe_from_predictions(preds, price_test))
+
+        return float(np.nanmean(sharpe_scores))
+
+    study = optuna.create_study(direction='maximize', sampler=TPESampler(seed=random_state))
     study.optimize(objective, n_trials=n_trials)
-    
-    # Return best hyperparameters
     return study.best_params
 
 def get_sample_weights(y, class_weight='balanced'):
@@ -325,7 +270,7 @@ def get_sample_weights(y, class_weight='balanced'):
         # No class weights
         return np.ones(len(y))
 
-def optimize_hyperparameters(model_type, X, y, n_trials=100, n_splits=5, random_state=42):
+def optimize_hyperparameters(model_type, X, y, prices, n_trials=100, n_splits=5, random_state=42):
     """
     Optimize hyperparameters for a given model type using Optuna.
     
@@ -352,9 +297,9 @@ def optimize_hyperparameters(model_type, X, y, n_trials=100, n_splits=5, random_
     if model_type == 'decision_tree':
         return optimize_decision_tree(X, y, n_trials, n_splits, random_state)
     elif model_type == 'random_forest':
-        return optimize_random_forest(X, y, n_trials, n_splits, random_state)
+        return optimize_random_forest(X, y, prices, n_trials, n_splits, random_state)
     elif model_type == 'xgboost':
-        return optimize_xgboost(X, y, n_trials, n_splits, random_state)
+        return optimize_xgboost(X, y, prices, n_trials, n_splits, random_state)
     else:
         raise ValueError(f"Unsupported model type: {model_type}")
 

--- a/src/models/model_factory.py
+++ b/src/models/model_factory.py
@@ -321,7 +321,7 @@ class ModelFactory:
             raise ValueError(f"Unknown model type: {model_type}")
 
     @classmethod
-    def create_optimized_model(cls, model_type, X=None, y=None, n_trials=None, regime=None, 
+    def create_optimized_model(cls, model_type, X=None, y=None, prices=None, n_trials=None, regime=None,
                                force_optimization=False):
         """
         Create a model with optimized hyperparameters using HyperparameterManager.
@@ -353,8 +353,8 @@ class ModelFactory:
         ValueError
             If force_optimization=True but X or y is None
         """
-        if force_optimization and (X is None or y is None):
-            raise ValueError("X and y must be provided when force_optimization=True")
+        if force_optimization and (X is None or y is None or prices is None):
+            raise ValueError("X, y, and prices must be provided when force_optimization=True")
             
         if not OPTUNA_AVAILABLE and force_optimization:
             raise ImportError("Optuna is not installed. Cannot optimize hyperparameters.")
@@ -364,6 +364,7 @@ class ModelFactory:
             model_type=model_type,
             X=X,
             y=y,
+            prices=prices,
             regime=regime,
             force_optimization=force_optimization,
             n_trials=n_trials

--- a/src/strategies/multi_timeframe_strategy.py
+++ b/src/strategies/multi_timeframe_strategy.py
@@ -1,0 +1,85 @@
+"""Multi-timeframe strategy wrapper for combining signals across timeframes."""
+
+from typing import List, Optional
+import numpy as np
+import pandas as pd
+
+from .base_strategy import BaseStrategy
+from src.backtesting.engine import BacktestEngine
+import config
+
+
+class MultiTimeframeStrategy(BaseStrategy):
+    """Run a base strategy on multiple timeframes and aggregate the signals."""
+
+    def __init__(self):
+        super().__init__()
+        self.base_strategy_name: str = 'tema'
+        self.timeframes: List[str] = []
+        self.combine_method: str = 'average'
+        self.weights: Optional[List[float]] = None
+        self.sub_strategies = []
+
+    def initialize(self, config: dict):
+        """Initialize multi-timeframe strategy with configuration."""
+        from .strategy_registry import StrategyRegistry  # local import to avoid circular
+        super().initialize(config)
+        self.base_strategy_name = config.get('base_strategy', 'tema')
+        self.timeframes = config.get('timeframes', ['5min', '15min', '1h', '1D'])
+        self.combine_method = config.get('combine_method', 'average')
+        self.weights = config.get('weights')
+
+        self.sub_strategies = []
+        for tf in self.timeframes:
+            strat = StrategyRegistry.get_strategy(self.base_strategy_name)
+            strat_config = config.copy()
+            strat_config['primary_timeframe'] = tf
+            strat.initialize(strat_config)
+            self.sub_strategies.append((tf, strat))
+
+    def generate_features(self, data):  # pragma: no cover - not used directly
+        raise NotImplementedError("MultiTimeframeStrategy delegates feature generation to sub-strategies")
+
+    def generate_signals(self, features, predictions, dates):  # pragma: no cover - not used
+        raise NotImplementedError("MultiTimeframeStrategy delegates signal generation to sub-strategies")
+
+    def _resample(self, data: pd.DataFrame, timeframe: str) -> pd.DataFrame:
+        if timeframe in ['5min', '5T', '5m']:
+            return data
+        agg = {'open': 'first', 'high': 'max', 'low': 'min', 'close': 'last', 'volume': 'sum'}
+        rules = {k: v for k, v in agg.items() if k in data.columns}
+        return data.resample(timeframe).agg(rules).dropna()
+
+    def _run_signals(self, strat: BaseStrategy, data: pd.DataFrame) -> pd.Series:
+        features, _, dates = strat.generate_features(data)
+        signals = strat.generate_signals(features, None, dates)
+        if 'date' in signals.columns:
+            signals = signals.set_index('date')
+        return signals['signal']
+
+    def backtest(self, data: pd.DataFrame, train_data: pd.DataFrame = None,
+                 test_data: pd.DataFrame = None, timeframe: str = '5min'):
+        base_index = data.index
+        symbol = self.config.get('symbol', 'SPY')
+        weights = self.weights or [1.0] * len(self.sub_strategies)
+        total_weight = float(sum(weights))
+        combined = np.zeros(len(base_index))
+
+        for (tf, strat), weight in zip(self.sub_strategies, weights):
+            tf_data = self._resample(data, tf) if tf != timeframe else data
+            sig = self._run_signals(strat, tf_data)
+            sig = sig.reindex(base_index, method='ffill').fillna(0)
+            combined += sig.values * weight
+
+        if self.combine_method == 'vote':
+            final_signal = np.sign(combined)
+        else:  # average
+            avg = combined / total_weight if total_weight else combined
+            final_signal = np.where(avg > 0.5, 1, np.where(avg < -0.5, -1, 0))
+
+        signals_df = pd.DataFrame({'date': base_index, 'symbol': symbol, 'signal': final_signal})
+        price_df = data[['close']].copy()
+        engine = BacktestEngine(initial_capital=config.INITIAL_CAPITAL,
+                                commission=self.config.get('commission', 0.0005),
+                                slippage=self.config.get('slippage', 0.0001))
+        return engine.run_backtest(signals_df, {symbol: price_df}, timeframe)

--- a/src/strategies/strategy_registry.py
+++ b/src/strategies/strategy_registry.py
@@ -13,6 +13,7 @@ from src.strategies.trend_following import TrendFollowingStrategy
 from src.strategies.regime_adaptive_strategy import RegimeAdaptiveStrategy
 from src.strategies.adapters import BBRSIADXAdapter, TEMAAdapter, QuodAdapter
 from src.strategies.hybrid_momentum_strategy import HybridMomentumMLStrategy
+from src.strategies.multi_timeframe_strategy import MultiTimeframeStrategy
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -35,6 +36,7 @@ class StrategyRegistry:
         'tema': TEMAAdapter,
         'quod': QuodAdapter,
         'hybrid_momentum': HybridMomentumMLStrategy,
+        'multi_timeframe': MultiTimeframeStrategy,
     }
     
     # Aliases for backward compatibility and convenience

--- a/strategy_configs.py
+++ b/strategy_configs.py
@@ -389,6 +389,13 @@ STRATEGY_CONFIGS = {
     'bb_rsi_adx_5min': BB_RSI_ADX_5MIN_CONFIG,
     'tema_5min': TEMA_5MIN_CONFIG,
     'hybrid_xgb_tema_5min': HYBRID_XGB_TEMA_5MIN_CONFIG,
+    'multi_tf_tema': {
+        'name': 'Multi-Timeframe TEMA',
+        'model_type': 'multi_timeframe',
+        'base_strategy': 'tema',
+        'timeframes': ['5min', '15min', '1h', '1D'],
+        'combine_method': 'average'
+    },
     # Meta-strategy configuration
     'meta_strategy': {
         'name': 'meta_strategy',

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -360,7 +360,9 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         print(f"\n=== Running strategy: {config['name']} ===")
 
         # Determine strategy type from config name
-        if 'meta_strategy' in config['name'].lower():
+        if config.get('model_type') == 'multi_timeframe' or 'multi_timeframe' in config['name'].lower():
+            strategy_type = 'multi_timeframe'
+        elif 'meta_strategy' in config['name'].lower():
             strategy_type = 'meta_strategy'
             # Dynamically import and register meta-strategy if needed
             if 'meta_strategy' not in StrategyRegistry.list_strategies():

--- a/tests/test_hyperparameter_trading_metric.py
+++ b/tests/test_hyperparameter_trading_metric.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import numpy as np
+
+from src.models.hyperparameter_optimization import optimize_decision_tree
+
+def test_optimize_decision_tree_returns_params():
+    np.random.seed(0)
+    dates = pd.date_range('2020-01-01', periods=60, freq='D')
+    X = pd.DataFrame({'feat': np.random.randn(60)}, index=dates)
+    y = pd.Series((np.random.randn(60) > 0).astype(int), index=dates)
+    prices = pd.Series(100 + np.cumsum(np.random.randn(60)), index=dates, name='close')
+    params = optimize_decision_tree(X, y, prices, n_trials=1, n_splits=2)
+    assert isinstance(params, dict)
+    assert 'max_depth' in params

--- a/tests/test_multi_timeframe_strategy.py
+++ b/tests/test_multi_timeframe_strategy.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pandas as pd
+
+from src.strategies.multi_timeframe_strategy import MultiTimeframeStrategy
+from src.strategies.base_strategy import BaseStrategy
+from src.backtesting.engine import BacktestEngine
+
+class DummyStrategy(BaseStrategy):
+    def initialize(self, config):
+        self.config = config
+    def generate_features(self, data):
+        return pd.DataFrame(index=data.index), None, data.index
+    def generate_signals(self, features, predictions, dates):
+        sig = np.where(np.arange(len(dates)) % 2 == 0, 1, -1)
+        return pd.DataFrame({'signal': sig}, index=dates)
+    def backtest(self, data, train_data=None, test_data=None, timeframe='5min'):
+        features, _, dates = self.generate_features(data)
+        signals = self.generate_signals(features, None, dates)
+        sig_df = signals.copy()
+        sig_df['symbol'] = 'SPY'
+        sig_df = sig_df.reset_index().rename(columns={'index': 'date'})
+        engine = BacktestEngine()
+        return engine.run_backtest(sig_df, data)
+
+
+def test_multi_timeframe_strategy_runs():
+    from src.strategies.strategy_registry import StrategyRegistry
+    StrategyRegistry.register_strategy('dummy', DummyStrategy)
+    dates = pd.date_range('2024-01-01', periods=20, freq='5min')
+    data = pd.DataFrame({
+        'open': np.linspace(100, 101, 20),
+        'high': np.linspace(100, 101, 20),
+        'low': np.linspace(100, 101, 20),
+        'close': np.linspace(100, 101, 20),
+        'volume': np.ones(20)
+    }, index=dates)
+    config = {
+        'name': 'MultiTF Dummy',
+        'model_type': 'multi_timeframe',
+        'base_strategy': 'dummy',
+        'timeframes': ['5min', '15min']
+    }
+    strategy = StrategyRegistry.get_strategy('multi_timeframe', config)
+    results = strategy.backtest(data, timeframe='5min')
+    assert 'performance' in results


### PR DESCRIPTION
## Summary
- Optimize decision tree, random forest, and XGBoost hyperparameters using backtested Sharpe ratios
- Introduce MultiTimeframeStrategy to aggregate signals across multiple timeframes
- Document Sharpe-based tuning and multi-timeframe ensemble usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950fb8676c8330a698a4b1a661b85f