### PR TITLE
Forward prices for decision tree hyperparameter search

### DIFF
--- a/src/models/hyperparameter_optimization.py
+++ b/src/models/hyperparameter_optimization.py
@@ -21,10 +21,10 @@ import optuna
 from optuna.samplers import TPESampler
 import config
 
-def optimize_decision_tree(X, y, n_trials=100, n_splits=5, random_state=42):
+def optimize_decision_tree(X, y, n_trials=100, n_splits=5, random_state=42, prices=None):
     """
     Optimize hyperparameters for Decision Tree model using Optuna.
-    
+
     Parameters:
     -----------
     X : pd.DataFrame
@@ -37,7 +37,9 @@ def optimize_decision_tree(X, y, n_trials=100, n_splits=5, random_state=42):
         Number of splits for TimeSeriesSplit (default: 5)
     random_state : int
         Random seed for reproducibility (default: 42)
-        
+    prices : pd.Series or None
+        Optional price series aligned with y (default: None)
+
     Returns:
     --------
     dict
@@ -325,7 +327,7 @@ def get_sample_weights(y, class_weight='balanced'):
         # No class weights
         return np.ones(len(y))
 
-def optimize_hyperparameters(model_type, X, y, n_trials=100, n_splits=5, random_state=42):
+def optimize_hyperparameters(model_type, X, y, n_trials=100, n_splits=5, random_state=42, prices=None):
     """
     Optimize hyperparameters for a given model type using Optuna.
     
@@ -337,6 +339,8 @@ def optimize_hyperparameters(model_type, X, y, n_trials=100, n_splits=5, random_
         Feature matrix
     y : pd.Series
         Target values
+    prices : pd.Series or None
+        Optional price series to align with y (default: None)
     n_trials : int
         Number of optimization trials (default: 100)
     n_splits : int
@@ -350,7 +354,7 @@ def optimize_hyperparameters(model_type, X, y, n_trials=100, n_splits=5, random_
         Best hyperparameters
     """
     if model_type == 'decision_tree':
-        return optimize_decision_tree(X, y, n_trials, n_splits, random_state)
+        return optimize_decision_tree(X, y, n_trials, n_splits, random_state, prices)
     elif model_type == 'random_forest':
         return optimize_random_forest(X, y, n_trials, n_splits, random_state)
     elif model_type == 'xgboost':


### PR DESCRIPTION
## Summary
- allow `optimize_hyperparameters` to accept optional price series
- forward price data when optimizing decision tree hyperparameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68951a5454748330b1799f7be5d60af1