### PR TITLE
Integrate JFK DSRsi and MPO-3TF momentum strategies

### DIFF
--- a/src/data/preprocessing.py
+++ b/src/data/preprocessing.py
@@ -105,6 +105,49 @@ def load_5min_data(train_file, test_file):
     
     return combined_data
 
+
+def load_1min_data(train_file, test_file):
+    """Load and combine 1-minute IBKR historical data files.
+
+    Parameters
+    ----------
+    train_file : str
+        Path to training data file (1-minute bars)
+    test_file : str
+        Path to testing data file (1-minute bars)
+
+    Returns
+    -------
+    pd.DataFrame
+        Combined and preprocessed 1-minute data
+    """
+    print(f"Loading 1-minute training data from {train_file}...")
+    train_data = pd.read_csv(train_file)
+
+    print(f"Loading 1-minute testing data from {test_file}...")
+    test_data = pd.read_csv(test_file)
+
+    combined_data = pd.concat([train_data, test_data])
+
+    # Parse timestamps and convert to timezone-naive UTC
+    combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
+    combined_data['date'] = combined_data['date'].dt.tz_convert(None)
+    combined_data.set_index('date', inplace=True)
+
+    combined_data = combined_data.sort_index()
+    combined_data.columns = combined_data.columns.str.lower()
+
+    missing_count = combined_data.isnull().sum().sum()
+    if missing_count > 0:
+        print(f"Warning: Found {missing_count} missing values in the data.")
+        combined_data = combined_data.dropna()
+        print(f"Dropped rows with missing values. New shape: {combined_data.shape}")
+
+    print(f"1-minute data loaded and preprocessed. Shape: {combined_data.shape}")
+    print(f"Date range: {combined_data.index.min()} to {combined_data.index.max()}")
+
+    return combined_data
+
 def preprocess_data(df):
     """
     Preprocess raw price data for model training.

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -195,7 +195,7 @@ def engineer_features(df, lookback_period=10, timeframe: str = 'daily'):
         'plus_di', 'minus_di'
     ]
 
-    if timeframe == '5min':
+    if timeframe in ['5min', '1min']:
         # Add intraday-specific features
         df_features['hour'] = df_features.index.hour
         df_features['minute'] = df_features.index.minute
@@ -496,7 +496,7 @@ def prepare_train_test_data(df, train_end_date=None, prune_features_flag=False,
         (X_train, X_test, y_train, y_test, dates_train, dates_test, scaler)
     """
     # Determine lookback based on timeframe
-    lookback = config.LOOKBACK_PERIOD_5MIN if timeframe == '5min' else config.LOOKBACK_PERIOD
+    lookback = config.LOOKBACK_PERIOD_5MIN if timeframe in ['5min', '1min'] else config.LOOKBACK_PERIOD
 
     # Add technical indicators
     df_features = add_technical_indicators(df, lookback)

--- a/src/strategies/adapters/__init__.py
+++ b/src/strategies/adapters/__init__.py
@@ -1,8 +1,7 @@
-"""
-Strategy adapters for momentum strategies.
-"""
+"""Strategy adapters for momentum strategies."""
 
-# Import adapters as they are implemented
 from .bbrsiadx_adapter import BBRSIADXAdapter
 from .tema_adapter import TEMAAdapter
 from .quod_adapter import QuodAdapter
+from .jfk_dsrsi_adapter import JFKDSRSIAdapter
+from .mpo_3tf_adapter import MPO3TFAdapter

--- a/src/strategies/adapters/jfk_dsrsi_adapter.py
+++ b/src/strategies/adapters/jfk_dsrsi_adapter.py
@@ -1,0 +1,164 @@
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from src.strategies.base_strategy import BaseStrategy
+from src.features.indicators import calculate_rsi, calculate_atr
+
+logger = logging.getLogger(__name__)
+
+
+def calculate_dsrsi(df: pd.DataFrame, length: int = 14, smoothing: int = 3) -> pd.Series:
+    """Compute Double Smoothed RSI."""
+    rsi1 = calculate_rsi(df, window=length)
+    rsi_df = pd.DataFrame({'close': rsi1})
+    return calculate_rsi(rsi_df, window=smoothing)
+
+
+def calculate_kps(df: pd.DataFrame, length: int = 14, smooth: int = 3) -> pd.Series:
+    """Simplified Kase Permission Stochastic indicator."""
+    lowest = df['low'].rolling(length).min()
+    highest = df['high'].rolling(length).max()
+    kps = 100 * (df['close'] - lowest) / (highest - lowest)
+    return kps.rolling(smooth).mean()
+
+
+class JFKDSRSIAdapter(BaseStrategy):
+    """JFK DSRsi momentum strategy adapter."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.dsrsi_length = 14
+        self.smoothing_period = 3
+        self.kps_length = 14
+        self.kps_smooth = 3
+        self.rsi_long_threshold = 60
+        self.rsi_short_threshold = 40
+        self.atr_length = 14
+        self.atr_stop_loss = 3
+        self.atr_take_profit = 3
+        self.position_size = 0.1
+
+    def initialize(self, config: Dict) -> None:
+        super().initialize(config)
+        self.dsrsi_length = config.get('dsrsi_length', self.dsrsi_length)
+        self.smoothing_period = config.get('smoothing_period', self.smoothing_period)
+        self.kps_length = config.get('kps_length', self.kps_length)
+        self.kps_smooth = config.get('kps_smooth', self.kps_smooth)
+        self.rsi_long_threshold = config.get('rsi_long_threshold', self.rsi_long_threshold)
+        self.rsi_short_threshold = config.get('rsi_short_threshold', self.rsi_short_threshold)
+        self.atr_length = config.get('atr_length', self.atr_length)
+        self.atr_stop_loss = config.get('atr_stop_loss', self.atr_stop_loss)
+        self.atr_take_profit = config.get('atr_take_profit', self.atr_take_profit)
+        self.position_size = config.get('position_size', self.position_size)
+        logger.info("JFKDSRSI adapter initialized with config")
+
+    def get_required_features(self) -> List[str]:
+        return ['close', 'high', 'low', 'volume']
+
+    def get_required_timeframes(self) -> List[str]:
+        timeframe = '5min'
+        if hasattr(self, 'config') and self.config:
+            timeframe = self.config.get('timeframe', timeframe)
+        return [timeframe]
+
+    def _add_indicators(self, data: pd.DataFrame) -> pd.DataFrame:
+        df = data.copy()
+        df['dsrsi'] = calculate_dsrsi(df, self.dsrsi_length, self.smoothing_period)
+        df['kps'] = calculate_kps(df, self.kps_length, self.kps_smooth)
+        df['atr'] = calculate_atr(df, self.atr_length)
+        return df
+
+    def generate_features(self, data: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series, pd.DatetimeIndex]:
+        df = self._add_indicators(data)
+        features = df[['close', 'dsrsi', 'kps', 'atr']].copy()
+        target = (df['close'].shift(-1) > df['close']).astype(int)
+        valid = ~(features.isna().any(axis=1) | target.isna())
+        features = features[valid]
+        target = target[valid]
+        dates = df.index[valid]
+        return features, target, dates
+
+    def generate_signals(self, features: pd.DataFrame, predictions: Optional[np.ndarray],
+                        dates: pd.DatetimeIndex) -> pd.DataFrame:
+        signals = pd.DataFrame(index=dates)
+        signals['date'] = dates
+        signals['symbol'] = self.config.get('symbol', 'SPY') if hasattr(self, 'config') and self.config else 'SPY'
+        signals['signal'] = 0
+        signals['entry_price'] = features['close']
+        atr = features['atr']
+        close = features['close']
+
+        long_cond = (features['dsrsi'] > self.rsi_long_threshold) & (features['kps'] > 50)
+        short_cond = (features['dsrsi'] < self.rsi_short_threshold) & (features['kps'] < 50)
+        signals.loc[long_cond, 'signal'] = 1
+        signals.loc[short_cond, 'signal'] = -1
+
+        signals['stop_loss'] = np.where(
+            signals['signal'] == 1,
+            close - atr * self.atr_stop_loss,
+            np.where(signals['signal'] == -1, close + atr * self.atr_stop_loss, np.nan)
+        )
+        signals['take_profit'] = np.where(
+            signals['signal'] == 1,
+            close + atr * self.atr_take_profit,
+            np.where(signals['signal'] == -1, close - atr * self.atr_take_profit, np.nan)
+        )
+        signals['position_size'] = np.where(signals['signal'] != 0, self.position_size, 0)
+        return signals
+
+    def apply_risk_management(self, signals: pd.DataFrame, prices: pd.DataFrame,
+                              features: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        return signals
+
+    def _calculate_backtest_metrics(self, signals: pd.DataFrame, prices: pd.DataFrame) -> Dict[str, any]:
+        aligned_prices = prices.loc[signals.index]
+        position = signals['signal'].shift(1).fillna(0)
+        returns = position * aligned_prices['close'].pct_change()
+
+        timeframe = self.config.get('timeframe', '5min') if hasattr(self, 'config') and self.config else '5min'
+        if timeframe in ['5min', '5T', '5m']:
+            annualization_factor = np.sqrt(78 * 252)
+            periods_per_year = 78 * 252
+        elif timeframe in ['1min', '1T', '1m']:
+            annualization_factor = np.sqrt(390 * 252)
+            periods_per_year = 390 * 252
+        else:
+            annualization_factor = np.sqrt(252)
+            periods_per_year = 252
+
+        total_return = (1 + returns).prod() - 1
+        sharpe_ratio = returns.mean() / returns.std() * annualization_factor if returns.std() > 0 else 0
+        max_drawdown = (returns.cumsum() - returns.cumsum().expanding().max()).min()
+        num_trades = (signals['signal'] != signals['signal'].shift(1)).sum()
+        win_rate = (returns > 0).sum() / (returns != 0).sum() if (returns != 0).sum() > 0 else 0
+        years = max(len(returns) / periods_per_year, 0.01)
+        ann_return = (1 + total_return) ** (1 / years) - 1
+
+        return {
+            'total_return': total_return,
+            'ann_return': ann_return,
+            'sharpe_ratio': sharpe_ratio,
+            'max_drawdown': max_drawdown,
+            'num_trades': num_trades,
+            'win_rate': win_rate,
+            'strategy': 'JFK-DSRSI'
+        }
+
+    def backtest(self, data: pd.DataFrame, train_data: Optional[pd.DataFrame] = None,
+                 test_data: Optional[pd.DataFrame] = None, timeframe: str = 'daily') -> Dict[str, any]:
+        if test_data is None:
+            test_data = data
+        features, _, dates = self.generate_features(test_data)
+        signals = self.generate_signals(features, None, dates)
+        signals = self.apply_risk_management(signals, test_data, features)
+        metrics = self._calculate_backtest_metrics(signals, test_data)
+        result = {
+            **metrics,
+            'trades': signals[signals['signal'] != 0],
+            'equity_curve': pd.DataFrame({'equity': (1 + metrics.get('total_return', 0))}, index=[test_data.index[-1]])
+        }
+        result['performance'] = metrics
+        return result

--- a/src/strategies/adapters/mpo_3tf_adapter.py
+++ b/src/strategies/adapters/mpo_3tf_adapter.py
@@ -1,0 +1,166 @@
+import logging
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from src.strategies.base_strategy import BaseStrategy
+from src.features.indicators import calculate_rsi, calculate_atr
+from src.features.multi_timeframe_features import MultiTimeframeAggregator
+
+logger = logging.getLogger(__name__)
+
+
+class MPO3TFAdapter(BaseStrategy):
+    """Multi-timeframe momentum strategy using RSI alignment."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.rsi_period = 14
+        self.rsi_upper = 60
+        self.rsi_lower = 40
+        self.atr_length = 14
+        self.atr_stop_loss = 3
+        self.atr_take_profit = 3
+        self.position_size = 0.1
+        self.aggregator = MultiTimeframeAggregator()
+
+    def initialize(self, config: Dict) -> None:
+        super().initialize(config)
+        self.rsi_period = config.get('rsi_period', self.rsi_period)
+        self.rsi_upper = config.get('rsi_upper', self.rsi_upper)
+        self.rsi_lower = config.get('rsi_lower', self.rsi_lower)
+        self.atr_length = config.get('atr_length', self.atr_length)
+        self.atr_stop_loss = config.get('atr_stop_loss', self.atr_stop_loss)
+        self.atr_take_profit = config.get('atr_take_profit', self.atr_take_profit)
+        self.position_size = config.get('position_size', self.position_size)
+        logger.info("MPO3TF adapter initialized with config")
+
+    def get_required_features(self) -> List[str]:
+        return ['close', 'high', 'low', 'volume']
+
+    def get_required_timeframes(self) -> List[str]:
+        timeframe = '1min'
+        if hasattr(self, 'config') and self.config:
+            timeframe = self.config.get('timeframe', timeframe)
+        return [timeframe]
+
+    def _add_indicators(self, data: pd.DataFrame) -> pd.DataFrame:
+        df = data.copy()
+        df['rsi_1m'] = calculate_rsi(df, window=self.rsi_period)
+
+        data_5 = self.aggregator.resample_data(df, '5T')
+        data_10 = self.aggregator.resample_data(df, '10T')
+        data_15 = self.aggregator.resample_data(df, '15T')
+
+        rsi_5 = calculate_rsi(data_5, window=self.rsi_period).reindex(df.index, method='ffill')
+        rsi_10 = calculate_rsi(data_10, window=self.rsi_period).reindex(df.index, method='ffill')
+        rsi_15 = calculate_rsi(data_15, window=self.rsi_period).reindex(df.index, method='ffill')
+
+        df['rsi_5m'] = rsi_5
+        df['rsi_10m'] = rsi_10
+        df['rsi_15m'] = rsi_15
+        df['atr'] = calculate_atr(df, self.atr_length)
+        return df
+
+    def generate_features(self, data: pd.DataFrame) -> Tuple[pd.DataFrame, pd.Series, pd.DatetimeIndex]:
+        df = self._add_indicators(data)
+        features = df[['close', 'rsi_1m', 'rsi_5m', 'rsi_10m', 'rsi_15m', 'atr']].copy()
+        target = (df['close'].shift(-1) > df['close']).astype(int)
+        valid = ~(features.isna().any(axis=1) | target.isna())
+        features = features[valid]
+        target = target[valid]
+        dates = df.index[valid]
+        return features, target, dates
+
+    def generate_signals(self, features: pd.DataFrame, predictions: Optional[np.ndarray],
+                        dates: pd.DatetimeIndex) -> pd.DataFrame:
+        signals = pd.DataFrame(index=dates)
+        signals['date'] = dates
+        signals['symbol'] = self.config.get('symbol', 'SPY') if hasattr(self, 'config') and self.config else 'SPY'
+        signals['signal'] = 0
+        signals['entry_price'] = features['close']
+        atr = features['atr']
+        close = features['close']
+
+        long_cond = (
+            (features['rsi_1m'] > self.rsi_upper) &
+            (features['rsi_5m'] > self.rsi_upper) &
+            (features['rsi_10m'] > self.rsi_upper) &
+            (features['rsi_15m'] > self.rsi_upper)
+        )
+        short_cond = (
+            (features['rsi_1m'] < self.rsi_lower) &
+            (features['rsi_5m'] < self.rsi_lower) &
+            (features['rsi_10m'] < self.rsi_lower) &
+            (features['rsi_15m'] < self.rsi_lower)
+        )
+        signals.loc[long_cond, 'signal'] = 1
+        signals.loc[short_cond, 'signal'] = -1
+
+        signals['stop_loss'] = np.where(
+            signals['signal'] == 1,
+            close - atr * self.atr_stop_loss,
+            np.where(signals['signal'] == -1, close + atr * self.atr_stop_loss, np.nan)
+        )
+        signals['take_profit'] = np.where(
+            signals['signal'] == 1,
+            close + atr * self.atr_take_profit,
+            np.where(signals['signal'] == -1, close - atr * self.atr_take_profit, np.nan)
+        )
+        signals['position_size'] = np.where(signals['signal'] != 0, self.position_size, 0)
+        return signals
+
+    def apply_risk_management(self, signals: pd.DataFrame, prices: pd.DataFrame,
+                              features: Optional[pd.DataFrame] = None) -> pd.DataFrame:
+        return signals
+
+    def _calculate_backtest_metrics(self, signals: pd.DataFrame, prices: pd.DataFrame) -> Dict[str, any]:
+        aligned_prices = prices.loc[signals.index]
+        position = signals['signal'].shift(1).fillna(0)
+        returns = position * aligned_prices['close'].pct_change()
+
+        timeframe = self.config.get('timeframe', '1min') if hasattr(self, 'config') and self.config else '1min'
+        if timeframe in ['1min', '1T', '1m']:
+            annualization_factor = np.sqrt(390 * 252)
+            periods_per_year = 390 * 252
+        elif timeframe in ['5min', '5T', '5m']:
+            annualization_factor = np.sqrt(78 * 252)
+            periods_per_year = 78 * 252
+        else:
+            annualization_factor = np.sqrt(252)
+            periods_per_year = 252
+
+        total_return = (1 + returns).prod() - 1
+        sharpe_ratio = returns.mean() / returns.std() * annualization_factor if returns.std() > 0 else 0
+        max_drawdown = (returns.cumsum() - returns.cumsum().expanding().max()).min()
+        num_trades = (signals['signal'] != signals['signal'].shift(1)).sum()
+        win_rate = (returns > 0).sum() / (returns != 0).sum() if (returns != 0).sum() > 0 else 0
+        years = max(len(returns) / periods_per_year, 0.01)
+        ann_return = (1 + total_return) ** (1 / years) - 1
+
+        return {
+            'total_return': total_return,
+            'ann_return': ann_return,
+            'sharpe_ratio': sharpe_ratio,
+            'max_drawdown': max_drawdown,
+            'num_trades': num_trades,
+            'win_rate': win_rate,
+            'strategy': 'MPO-3TF'
+        }
+
+    def backtest(self, data: pd.DataFrame, train_data: Optional[pd.DataFrame] = None,
+                 test_data: Optional[pd.DataFrame] = None, timeframe: str = 'daily') -> Dict[str, any]:
+        if test_data is None:
+            test_data = data
+        features, _, dates = self.generate_features(test_data)
+        signals = self.generate_signals(features, None, dates)
+        signals = self.apply_risk_management(signals, test_data, features)
+        metrics = self._calculate_backtest_metrics(signals, test_data)
+        result = {
+            **metrics,
+            'trades': signals[signals['signal'] != 0],
+            'equity_curve': pd.DataFrame({'equity': (1 + metrics.get('total_return', 0))}, index=[test_data.index[-1]])
+        }
+        result['performance'] = metrics
+        return result

--- a/src/strategies/strategy_registry.py
+++ b/src/strategies/strategy_registry.py
@@ -11,7 +11,13 @@ from typing import Dict, Type, Optional, List
 from src.strategies.base_strategy import BaseStrategy
 from src.strategies.trend_following import TrendFollowingStrategy
 from src.strategies.regime_adaptive_strategy import RegimeAdaptiveStrategy
-from src.strategies.adapters import BBRSIADXAdapter, TEMAAdapter, QuodAdapter
+from src.strategies.adapters import (
+    BBRSIADXAdapter,
+    TEMAAdapter,
+    QuodAdapter,
+    JFKDSRSIAdapter,
+    MPO3TFAdapter,
+)
 from src.strategies.hybrid_momentum_strategy import HybridMomentumMLStrategy
 from src.strategies.multi_timeframe_strategy import MultiTimeframeStrategy
 
@@ -35,6 +41,8 @@ class StrategyRegistry:
         'bb_rsi_adx': BBRSIADXAdapter,
         'tema': TEMAAdapter,
         'quod': QuodAdapter,
+        'jfk_dsrsi': JFKDSRSIAdapter,
+        'mpo_3tf': MPO3TFAdapter,
         'hybrid_momentum': HybridMomentumMLStrategy,
         'multi_timeframe': MultiTimeframeStrategy,
     }
@@ -45,6 +53,8 @@ class StrategyRegistry:
         'trend': 'trend_following',
         'regime': 'regime_adaptive',
         'adaptive': 'regime_adaptive',
+        'jfk': 'jfk_dsrsi',
+        'mpo': 'mpo_3tf',
     }
     
     # Performance tracking for strategies (optional)

--- a/strategy_configs.py
+++ b/strategy_configs.py
@@ -292,6 +292,51 @@ QUOD_CONFIG = {
     'allow_same_bar_exit': True
 }
 
+# JFK-DSRSI Strategy
+JFK_DSRSI_CONFIG = {
+    'name': 'JFK-DSRSI',
+    'model_type': 'jfk_dsrsi',
+    'symbol': 'SPY',
+    'position_size': 0.1,
+    'timeframe': '5min',
+    'dsrsi_length': 14,
+    'smoothing_period': 3,
+    'kps_length': 14,
+    'kps_smooth': 3,
+    'rsi_long_threshold': 60,
+    'rsi_short_threshold': 40,
+    'atr_length': 14,
+    'atr_stop_loss': 3,
+    'atr_take_profit': 3,
+}
+
+JFK_DSRSI_1MIN_CONFIG = {
+    **JFK_DSRSI_CONFIG,
+    'name': 'JFK-DSRSI (1min)',
+    'timeframe': '1min',
+}
+
+# MPO-3TF Strategy
+MPO_3TF_CONFIG = {
+    'name': 'MPO-3TF',
+    'model_type': 'mpo_3tf',
+    'symbol': 'SPY',
+    'position_size': 0.1,
+    'timeframe': '1min',
+    'rsi_period': 14,
+    'rsi_upper': 60,
+    'rsi_lower': 40,
+    'atr_length': 14,
+    'atr_stop_loss': 3,
+    'atr_take_profit': 3,
+}
+
+MPO_3TF_5MIN_CONFIG = {
+    **MPO_3TF_CONFIG,
+    'name': 'MPO-3TF (5min)',
+    'timeframe': '5min',
+}
+
 # 5-Minute Strategy Configurations
 
 # BB-RSI-ADX 5-Minute Configuration
@@ -385,6 +430,10 @@ STRATEGY_CONFIGS = {
     'bb_rsi_adx': BB_RSI_ADX_CONFIG,
     'tema': TEMA_CONFIG,
     'quod': QUOD_CONFIG,
+    'jfk_dsrsi': JFK_DSRSI_CONFIG,
+    'jfk_dsrsi_1min': JFK_DSRSI_1MIN_CONFIG,
+    'mpo_3tf': MPO_3TF_CONFIG,
+    'mpo_3tf_5min': MPO_3TF_5MIN_CONFIG,
     # 5-minute momentum strategies
     'bb_rsi_adx_5min': BB_RSI_ADX_5MIN_CONFIG,
     'tema_5min': TEMA_5MIN_CONFIG,

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -16,7 +16,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from datetime import datetime
 
-from src.data.preprocessing import preprocess_data, load_5min_data
+from src.data.preprocessing import preprocess_data, load_5min_data, load_1min_data
 from src.strategies.trend_following import TrendFollowingStrategy
 from src.strategies.regime_adaptive_strategy import RegimeAdaptiveStrategy
 from src.strategies.strategy_registry import StrategyRegistry
@@ -44,25 +44,28 @@ def load_data(data_path, symbol='SPY', timeframe='daily'):
     symbol : str, default='SPY'
         Symbol for the data
     timeframe : str, default='daily'
-        Data timeframe - 'daily' or '5min'
+        Data timeframe - 'daily', '5min', or '1min'
         
     Returns:
     --------
     pd.DataFrame
         Preprocessed price data
     """
-    # Handle 5-minute data specifically
-    if timeframe == '5min':
-        # Use specific 5-minute data files
-        train_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_5_mins_2023-2024.csv')
-        test_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_5_mins_2025.csv')
-        
+    # Handle intraday data specifically
+    if timeframe in ['5min', '1min']:
+        if timeframe == '5min':
+            train_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_5_mins_2023-2024.csv')
+            test_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_5_mins_2025.csv')
+            loader = load_5min_data
+        else:
+            train_file = os.path.join(data_path, f'historical_data_INDEX_{symbol}_1_min_2023-2024.csv')
+            test_file = os.path.join(data_path, f'historical_data_INDEX_{symbol}_1_min_2025.csv')
+            loader = load_1min_data
+
         if not os.path.exists(train_file) or not os.path.exists(test_file):
-            raise FileNotFoundError(f"5-minute data files not found for {symbol}")
-        
-        # Use the dedicated 5-minute data loading function
-        df = load_5min_data(train_file, test_file)
-        # Don't preprocess again as load_5min_data already handles it
+            raise FileNotFoundError(f"{timeframe} data files not found for {symbol}")
+
+        df = loader(train_file, test_file)
         return df
     
     # Original logic for daily data
@@ -135,8 +138,9 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
         top_n_features = config.TOP_N_FEATURES
     
     # Determine lookback period based on timeframe
-    lookback_period = config.LOOKBACK_PERIOD_5MIN if timeframe == '5min' else config.LOOKBACK_PERIOD
-    print(f"Using lookback period: {lookback_period} {'bars' if timeframe == '5min' else 'days'}")
+    intraday = timeframe in ['5min', '1min']
+    lookback_period = config.LOOKBACK_PERIOD_5MIN if intraday else config.LOOKBACK_PERIOD
+    print(f"Using lookback period: {lookback_period} {'bars' if intraday else 'days'}")
     
     # Add technical indicators with appropriate lookback
     df_features = add_technical_indicators(df, lookback_period)
@@ -536,7 +540,7 @@ def get_strategy_configs(use_optimized_params=False, include_momentum=False, tim
     include_momentum : bool
         Whether to include momentum strategies
     timeframe : str
-        Data timeframe - 'daily' or '5min'
+        Data timeframe - 'daily', '5min', or '1min'
         
     Returns:
     --------
@@ -544,7 +548,7 @@ def get_strategy_configs(use_optimized_params=False, include_momentum=False, tim
         List of strategy configurations
     """
     # Use predefined strategy configurations from strategy_configs.py
-    if timeframe == '5min':
+    if timeframe in ['5min', '1min']:
         strategy_configs = [
             STRATEGY_CONFIGS['decision_tree_5min'].copy(),
             STRATEGY_CONFIGS['random_forest_5min'].copy(),
@@ -565,7 +569,7 @@ def get_strategy_configs(use_optimized_params=False, include_momentum=False, tim
     
     # Add momentum strategies if requested
     if include_momentum:
-        if timeframe == '5min':
+        if timeframe in ['5min', '1min']:
             # Use 5-minute optimized configurations
             strategy_configs.extend([
                 STRATEGY_CONFIGS['bb_rsi_adx_5min'].copy(),
@@ -665,7 +669,7 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
     print(f"Testing data: {len(test_data)} rows ({test_data.index[0]} to {test_data.index[-1]})")
     
     # Check if model_type is a momentum strategy or meta-strategy
-    momentum_strategies = ['bb_rsi_adx', 'tema', 'quod', 'meta_strategy']
+    momentum_strategies = ['bb_rsi_adx', 'tema', 'quod', 'jfk_dsrsi', 'mpo_3tf', 'meta_strategy']
     
     if model_type in momentum_strategies:
         # For momentum strategies, use the model type as the strategy type
@@ -679,21 +683,21 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         config_key = None
         
         if model_type == 'decision_tree':
-            if timeframe == '5min':
+            if timeframe in ['5min', '1min']:
                 config_key = 'decision_tree_5min'
             else:
                 config_key = 'decision_tree_calibrated' if calibrate else 'decision_tree'
         elif model_type == 'random_forest':
-            if timeframe == '5min':
+            if timeframe in ['5min', '1min']:
                 config_key = 'random_forest_5min'
             else:
                 config_key = 'random_forest_calibrated' if calibrate else 'random_forest'
         elif model_type == 'xgboost':
-            config_key = 'xgboost_5min' if timeframe == '5min' else 'xgboost_confidence'
+            config_key = 'xgboost_5min' if timeframe in ['5min', '1min'] else 'xgboost_confidence'
         elif model_type == 'stacking':
             config_key = 'stacking'
         elif model_type in ['transformer', 'hybrid']:
-            config_key = 'transformer_5min' if (model_type == 'transformer' and timeframe == '5min') else None
+            config_key = 'transformer_5min' if (model_type == 'transformer' and timeframe in ['5min', '1min']) else None
         
         if strategy_type == 'regime_adaptive' and model_type == 'random_forest':
             config_key = 'regime_adaptive_rf'
@@ -702,38 +706,16 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
     if config_key and config_key in STRATEGY_CONFIGS:
         config = STRATEGY_CONFIGS[config_key].copy()
     elif model_type in momentum_strategies:
-        # Create configuration for momentum strategies
-        config = {
-            'name': model_type.upper().replace('_', '-'),
-            'symbol': symbol,
-            'position_size': 0.1,
-            'primary_timeframe': '1h'  # Default timeframe
-        }
-        
-        # Add strategy-specific default parameters
-        if model_type == 'bb_rsi_adx':
-            config.update({
-                'bb_period': 20,
-                'rsi_period': 14,
-                'adx_primary_threshold': 20,
-                'adx_secondary_threshold': 40
-            })
-        elif model_type == 'tema':
-            config.update({
-                'tema_primary_fast': 10,
-                'tema_primary_slow': 80,
-                'adx_threshold': 40,
-                'use_dual_timeframe': True
-            })
-        elif model_type == 'quod':
-            config.update({
-                'use_stoch_reversal': True,
-                'use_stoch_pullback': True,
-                'use_d60_trend_exit': True,
-                'primary_timeframe': '5T'  # 5-minute default for Quod
-            })
-        elif model_type == 'meta_strategy':
-            config = STRATEGY_CONFIGS.get('meta_strategy', {}).copy()
+        config = STRATEGY_CONFIGS.get(model_type, {}).copy()
+        if not config:
+            config = {
+                'name': model_type.upper().replace('_', '-'),
+                'symbol': symbol,
+                'position_size': 0.1,
+                'primary_timeframe': '1h'
+            }
+        config.setdefault('symbol', symbol)
+        if model_type == 'meta_strategy':
             if performance_window is not None:
                 config['performance_window'] = performance_window
             if switch_cooldown is not None:
@@ -917,7 +899,7 @@ def parse_arguments():
     
     parser.add_argument('--model', type=str,
                         choices=['decision_tree', 'random_forest', 'xgboost', 'stacking', 'transformer', 'hybrid',
-                                 'bb_rsi_adx', 'tema', 'quod', 'meta_strategy', 'hybrid_momentum'],
+                                 'bb_rsi_adx', 'tema', 'quod', 'jfk_dsrsi', 'mpo_3tf', 'meta_strategy', 'hybrid_momentum'],
                         default='random_forest',
                         help='Model type for single mode (default: random_forest)')
     
@@ -960,7 +942,7 @@ def parse_arguments():
                         help='Include momentum strategies (BB-RSI-ADX, TEMA, Quod) in comparison mode')
     
     parser.add_argument('--timeframe',
-                        choices=['daily', '5min'],
+                        choices=['daily', '5min', '1min'],
                         default='daily',
                         help='Data timeframe to use (default: daily)')
 

--- a/tests/test_intraday_features.py
+++ b/tests/test_intraday_features.py
@@ -4,8 +4,8 @@ import pandas as pd
 from src.features.feature_engineering import engineer_features
 
 
-def _make_intraday_dataframe(rows: int = 100) -> pd.DataFrame:
-    index = pd.date_range('2024-01-02 09:30', periods=rows, freq='5min')
+def _make_intraday_dataframe(rows: int = 100, freq: str = '5min') -> pd.DataFrame:
+    index = pd.date_range('2024-01-02 09:30', periods=rows, freq=freq)
     base = np.arange(rows, dtype=float)
     data = pd.DataFrame({
         'open': base,
@@ -33,6 +33,15 @@ def _make_daily_dataframe(rows: int = 100) -> pd.DataFrame:
 def test_engineer_features_adds_intraday_columns():
     df = _make_intraday_dataframe()
     X, y, dates = engineer_features(df, lookback_period=5, timeframe='5min')
+    expected = {
+        'hour', 'minute', 'ema_5', 'rsi_5', 'volatility_5', 'lag_return_1', 'lag_return_3'
+    }
+    assert expected.issubset(set(X.columns))
+
+
+def test_engineer_features_adds_intraday_columns_1min():
+    df = _make_intraday_dataframe(freq='1min')
+    X, y, dates = engineer_features(df, lookback_period=5, timeframe='1min')
     expected = {
         'hour', 'minute', 'ema_5', 'rsi_5', 'volatility_5', 'lag_return_1', 'lag_return_3'
     }


### PR DESCRIPTION
## Summary
- add JFKDSRSIAdapter implementing double-smoothed RSI and simplified Kase Permission Stochastic with ATR stops
- add MPO3TFAdapter to align 1/5/10/15-minute RSIs and apply ATR-based risk management
- register new strategies, expose them via CLI and configs for 5min/1min usage

## Testing
- `pytest -q`
- `python strategy_runner.py --data data/raw --model jfk_dsrsi --mode single --output tmp_jfk --timeframe 5min --symbol SPY` *(fails: 5min data files not found for SPY)*
- `python strategy_runner.py --data data/raw --model mpo_3tf --mode single --output tmp_mpo --timeframe 1min --symbol SPX` *(fails: 1min data files not found for SPX)*

------
https://chatgpt.com/codex/tasks/task_e_689d026f74c483309651e2de820828cd