### PR TITLE
Add SPX intraday support and integrate JFK-DSRSI & MPO-3TF strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ Ensure 5‑minute historical CSV files are available under `data/raw/` with name
 python strategy_runner.py --data data/raw --model random_forest --timeframe 5min --output rf_5min
 ```
 
+### SPX Data & New Momentum Strategies
+
+The JFK-DSRSI and MPO-3TF momentum strategies support both SPY and SPX symbols. Use the new CLI options to specify asset type and custom data files:
+
+```bash
+python strategy_runner.py --data data/raw --model jfk_dsrsi --timeframe 5min \
+    --symbol SPX --asset-type INDEX
+```
+
+By default, the system searches `data/raw` for intraday files. You can override file discovery with `--train-data` and `--test-data`. All timestamps are normalized to timezone-naive UTC to ensure consistent comparisons.
+
 ### Level 1: Basic Functionality Tests
 
 #### 1.1 Smoke Tests - Basic Strategy Execution

--- a/data/raw/README.md
+++ b/data/raw/README.md
@@ -4,7 +4,11 @@ This directory contains raw price data files obtained from IBKR or other sources
 
 ## Expected Files
 
-- historical_data_STOCK_SPY_1_day2000-2009.csv
-- historical_data_STOCK_SPY_1_day2010-2025.csv
+- `historical_data_STOCK_SPY_1_day2000-2009.csv`
+- `historical_data_STOCK_SPY_1_day2010-2025.csv`
+- `historical_data_STOCK_SPY_5_mins_*.csv`
+- `historical_data_STOCK_SPY_1_min_*.csv`
+- `historical_data_INDEX_SPX_5_mins_*.csv`
+- `historical_data_INDEX_SPX_1_min_*.csv`
 
-Place your data files here before running the main script.
+Intraday filenames follow the pattern `historical_data_{ASSET}_{SYMBOL}_{TIMEFRAME}_{DATE-RANGE}.csv`. `ASSET` is either `STOCK` or `INDEX` and timestamps should be UTC without timezone information.

--- a/docs/jfk_dsrsi_mpo3tf_integration.md
+++ b/docs/jfk_dsrsi_mpo3tf_integration.md
@@ -49,13 +49,19 @@ These scripts contain the indicator calculations, signal rules, and ATR-based ri
      ```bash
      python strategy_runner.py --data data/raw --model jfk_dsrsi --mode single --output results_jfk_5m --timeframe 5min --symbol SPY
      python strategy_runner.py --data data/raw --model jfk_dsrsi --mode single --output results_jfk_1m --timeframe 1min --symbol SPX
-     python strategy_runner.py --data data/raw --model mpo_3tf --mode single --output results_mpo_5m --timeframe 5min --symbol SPY
-     python strategy_runner.py --data data/raw --model mpo_3tf --mode single --output results_mpo_1m --timeframe 1min --symbol SPX
-     ```
+    python strategy_runner.py --data data/raw --model mpo_3tf --mode single --output results_mpo_5m --timeframe 5min --symbol SPY
+    python strategy_runner.py --data data/raw --model mpo_3tf --mode single --output results_mpo_1m --timeframe 1min --symbol SPX
+    ```
 
 6. **Documentation and Meta-Strategy Integration**
    - Update project documentation to describe the strategies, their parameters, and usage examples.
    - Add mappings so `MetaStrategy` can select these strategies; regime definitions will need to be extended.
+
+### Updated CLI Options
+
+- `--asset-type` to specify `STOCK` or `INDEX`
+- `--train-data` and `--test-data` for explicit file paths
+- Timestamps are normalized to timezone-naive UTC during loading
 
 ## Open Questions
 - **Default Parameters:** final hyper‑optimized parameter sets for 1‑minute and 5‑minute operation will be supplied later.

--- a/src/data/preprocessing.py
+++ b/src/data/preprocessing.py
@@ -5,8 +5,17 @@ Module for preprocessing raw data.
 
 import pandas as pd
 import numpy as np
+from typing import Union, List
 
 # src/data/preprocessing.py (Add this function)
+
+def _load_csv_files(files: Union[str, List[str]]) -> pd.DataFrame:
+    """Helper to load one or multiple CSV files and concatenate."""
+    if isinstance(files, list):
+        dfs = [pd.read_csv(f) for f in files]
+        return pd.concat(dfs)
+    return pd.read_csv(files)
+
 
 def load_ibkr_data(train_file, test_file):
     """
@@ -26,16 +35,17 @@ def load_ibkr_data(train_file, test_file):
     """
     # Load training and testing data
     print(f"Loading training data from {train_file}...")
-    train_data = pd.read_csv(train_file)
-    
+    train_data = _load_csv_files(train_file)
+
     print(f"Loading testing data from {test_file}...")
-    test_data = pd.read_csv(test_file)
+    test_data = _load_csv_files(test_file)
     
     # Combine the data
     combined_data = pd.concat([train_data, test_data])
     
     # Convert date column to datetime and set as index
-    combined_data['date'] = pd.to_datetime(combined_data['date'])
+    combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
+    combined_data['date'] = combined_data['date'].dt.tz_convert('UTC').dt.tz_localize(None)
     combined_data.set_index('date', inplace=True)
     
     # Sort by date (no need to reverse since IBKR data is already in chronological order)
@@ -72,18 +82,17 @@ def load_5min_data(train_file, test_file):
     """
     # Load training and testing data
     print(f"Loading 5-minute training data from {train_file}...")
-    train_data = pd.read_csv(train_file)
-    
+    train_data = _load_csv_files(train_file)
+
     print(f"Loading 5-minute testing data from {test_file}...")
-    test_data = pd.read_csv(test_file)
+    test_data = _load_csv_files(test_file)
     
     # Combine the data
     combined_data = pd.concat([train_data, test_data])
     
     # Convert date column to datetime and handle timezone
-    combined_data['date'] = pd.to_datetime(combined_data['date'])
-    # Remove timezone info for consistency with existing code
-    combined_data['date'] = combined_data['date'].dt.tz_localize(None)
+    combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
+    combined_data['date'] = combined_data['date'].dt.tz_convert('UTC').dt.tz_localize(None)
     combined_data.set_index('date', inplace=True)
     
     # Sort by date
@@ -122,16 +131,16 @@ def load_1min_data(train_file, test_file):
         Combined and preprocessed 1-minute data
     """
     print(f"Loading 1-minute training data from {train_file}...")
-    train_data = pd.read_csv(train_file)
+    train_data = _load_csv_files(train_file)
 
     print(f"Loading 1-minute testing data from {test_file}...")
-    test_data = pd.read_csv(test_file)
+    test_data = _load_csv_files(test_file)
 
     combined_data = pd.concat([train_data, test_data])
 
     # Parse timestamps and convert to timezone-naive UTC
     combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
-    combined_data['date'] = combined_data['date'].dt.tz_convert(None)
+    combined_data['date'] = combined_data['date'].dt.tz_convert('UTC').dt.tz_localize(None)
     combined_data.set_index('date', inplace=True)
 
     combined_data = combined_data.sort_index()

--- a/src/strategies/meta_strategy.py
+++ b/src/strategies/meta_strategy.py
@@ -56,7 +56,7 @@ class MetaStrategy(BaseStrategy):
         
         # Load configured strategies
         self.available_strategies = {}
-        strategy_names = self.config.get('strategies', ['quod', 'tema', 'bb_rsi_adx'])
+        strategy_names = self.config.get('strategies', ['quod', 'tema', 'bb_rsi_adx', 'jfk_dsrsi', 'mpo_3tf'])
         
         for name in strategy_names:
             try:
@@ -90,11 +90,11 @@ class MetaStrategy(BaseStrategy):
         return {
             'strong_uptrend': 'tema',      # Trend following
             'uptrend': 'tema',
-            'weak_uptrend': 'bb_rsi_adx',  # Momentum
-            'volatile_neutral': 'bb_rsi_adx',
+            'weak_uptrend': 'jfk_dsrsi',  # Additional momentum strategy
+            'volatile_neutral': 'mpo_3tf',
             'neutral': 'quod',             # Mean reversion
             'low_vol_neutral': 'quod',
-            'weak_downtrend': 'bb_rsi_adx',
+            'weak_downtrend': 'mpo_3tf',
             'downtrend': 'tema',
             'strong_downtrend': 'tema'
         }

--- a/strategy_configs.py
+++ b/strategy_configs.py
@@ -316,6 +316,13 @@ JFK_DSRSI_1MIN_CONFIG = {
     'timeframe': '1min',
 }
 
+JFK_DSRSI_SPX_CONFIG = {
+    **JFK_DSRSI_CONFIG,
+    'name': 'JFK-DSRSI SPX',
+    'symbol': 'SPX',
+    'asset_type': 'INDEX'
+}
+
 # MPO-3TF Strategy
 MPO_3TF_CONFIG = {
     'name': 'MPO-3TF',
@@ -335,6 +342,13 @@ MPO_3TF_5MIN_CONFIG = {
     **MPO_3TF_CONFIG,
     'name': 'MPO-3TF (5min)',
     'timeframe': '5min',
+}
+
+MPO_3TF_SPX_CONFIG = {
+    **MPO_3TF_CONFIG,
+    'name': 'MPO-3TF SPX',
+    'symbol': 'SPX',
+    'asset_type': 'INDEX'
 }
 
 # 5-Minute Strategy Configurations
@@ -395,6 +409,28 @@ HYBRID_XGB_TEMA_5MIN_CONFIG = {
     'timeframe': '5min'
 }
 
+HYBRID_XGB_JFK_5MIN_CONFIG = {
+    'name': 'Hybrid XGBoost+JFK-DSRSI (5min)',
+    'model_type': 'hybrid_momentum',
+    'ml_model_type': 'xgboost',
+    'ml_model_params': XGBOOST_5MIN_CONFIG['model_params'],
+    'momentum_strategy': 'jfk_dsrsi',
+    'agree_only': True,
+    'weights': (0.3, 0.7),
+    'timeframe': '5min'
+}
+
+HYBRID_XGB_MPO_5MIN_CONFIG = {
+    'name': 'Hybrid XGBoost+MPO-3TF (5min)',
+    'model_type': 'hybrid_momentum',
+    'ml_model_type': 'xgboost',
+    'ml_model_params': XGBOOST_5MIN_CONFIG['model_params'],
+    'momentum_strategy': 'mpo_3tf',
+    'agree_only': True,
+    'weights': (0.3, 0.7),
+    'timeframe': '5min'
+}
+
 # All strategy configurations
 STRATEGY_CONFIGS = {
     'decision_tree': DECISION_TREE_CONFIG,
@@ -432,12 +468,16 @@ STRATEGY_CONFIGS = {
     'quod': QUOD_CONFIG,
     'jfk_dsrsi': JFK_DSRSI_CONFIG,
     'jfk_dsrsi_1min': JFK_DSRSI_1MIN_CONFIG,
+    'jfk_dsrsi_spx': JFK_DSRSI_SPX_CONFIG,
     'mpo_3tf': MPO_3TF_CONFIG,
     'mpo_3tf_5min': MPO_3TF_5MIN_CONFIG,
+    'mpo_3tf_spx': MPO_3TF_SPX_CONFIG,
     # 5-minute momentum strategies
     'bb_rsi_adx_5min': BB_RSI_ADX_5MIN_CONFIG,
     'tema_5min': TEMA_5MIN_CONFIG,
     'hybrid_xgb_tema_5min': HYBRID_XGB_TEMA_5MIN_CONFIG,
+    'hybrid_xgb_jfk_5min': HYBRID_XGB_JFK_5MIN_CONFIG,
+    'hybrid_xgb_mpo_5min': HYBRID_XGB_MPO_5MIN_CONFIG,
     'multi_tf_tema': {
         'name': 'Multi-Timeframe TEMA',
         'model_type': 'multi_timeframe',

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -11,6 +11,8 @@ This script provides functionality to:
 
 import os
 import argparse
+import glob
+import re
 import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
@@ -33,7 +35,43 @@ from src.features.feature_engineering import (
 from strategy_configs import STRATEGY_CONFIGS
 import config
 
-def load_data(data_path, symbol='SPY', timeframe='daily'):
+def find_data_files(data_dir, symbol, timeframe, train_files=None, test_files=None, asset_type=None):
+    """Discover train/test data files based on patterns."""
+    if train_files and test_files:
+        return train_files if isinstance(train_files, list) else [train_files], \
+               test_files if isinstance(test_files, list) else [test_files]
+
+    tf_pattern = '5_mins' if timeframe == '5min' else '1_min'
+    pattern = f"historical_data_*_{symbol}_{tf_pattern}_*.csv"
+    files = glob.glob(os.path.join(data_dir, pattern))
+    if asset_type:
+        files = [f for f in files if f"_{asset_type.upper()}_" in os.path.basename(f)]
+    if not files:
+        raise FileNotFoundError(f"No {timeframe} files found for {symbol} in {data_dir}")
+
+    def extract_start(f):
+        m = re.search(r'_(\d{4}[A-Za-z]*\d*)-\d', os.path.basename(f))
+        return m.group(1) if m else os.path.basename(f)
+
+    files.sort(key=extract_start)
+    if len(files) == 1:
+        return [files[0]], [files[0]]
+    return files[:-1], [files[-1]]
+
+
+def validate_data_files(file_paths):
+    """Basic validation for data files."""
+    for path in file_paths:
+        df = pd.read_csv(path)
+        if 'date' in df.columns:
+            dates = pd.to_datetime(df['date'], utc=True)
+            if not dates.is_monotonic_increasing:
+                print(f"Warning: timestamps not increasing in {path}")
+            if dates.dt.tz is not None:
+                print(f"Warning: timezone-aware timestamps in {path}")
+
+
+def load_data(data_path, symbol='SPY', timeframe='daily', train_data=None, test_data=None, asset_type=None):
     """
     Load and preprocess historical price data.
     
@@ -53,25 +91,19 @@ def load_data(data_path, symbol='SPY', timeframe='daily'):
     """
     # Handle intraday data specifically
     if timeframe in ['5min', '1min']:
-        if timeframe == '5min':
-            train_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_5_mins_2023-2024.csv')
-            test_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_5_mins_2025.csv')
-            loader = load_5min_data
-        else:
-            train_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_1_min_2022Aug-2024Aug.csv')
-            test_file = os.path.join(data_path, f'historical_data_STOCK_{symbol}_1_min_2024Aug-2025Aug.csv')
-            loader = load_1min_data
-
-        if not os.path.exists(train_file) or not os.path.exists(test_file):
-            raise FileNotFoundError(f"{timeframe} data files not found for {symbol}")
-
-        df = loader(train_file, test_file)
+        train_files, test_files = find_data_files(
+            data_path, symbol, timeframe, train_data, test_data, asset_type
+        )
+        validate_data_files(train_files + test_files)
+        loader = load_5min_data if timeframe == '5min' else load_1min_data
+        df = loader(train_files, test_files)
         return df
     
     # Original logic for daily data
     if os.path.isfile(data_path):
         # Load data from single file
         df = pd.read_csv(data_path, index_col=0, parse_dates=True)
+        df.index = pd.to_datetime(df.index, utc=True).tz_convert('UTC').tz_localize(None)
     else:
         # Look for CSV files in the directory
         csv_files = [f for f in os.listdir(data_path) if f.endswith('.csv') and symbol in f and '5_mins' not in f]
@@ -83,7 +115,9 @@ def load_data(data_path, symbol='SPY', timeframe='daily'):
         dfs = []
         for file in csv_files:
             file_path = os.path.join(data_path, file)
-            dfs.append(pd.read_csv(file_path, index_col=0, parse_dates=True))
+            temp = pd.read_csv(file_path, index_col=0, parse_dates=True)
+            temp.index = pd.to_datetime(temp.index, utc=True).tz_convert('UTC').tz_localize(None)
+            dfs.append(temp)
         
         df = pd.concat(dfs)
         
@@ -129,9 +163,16 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
     os.makedirs(audit_dir, exist_ok=True)
     
     print(f"\n=== Running Feature Audit with {model_type} ===")
-    
+
     # Load and prepare data
-    df = load_data(data_path, symbol=symbol, timeframe=timeframe)
+    df = load_data(
+        data_path,
+        symbol=symbol,
+        timeframe=timeframe,
+        train_data=train_data,
+        test_data=test_data,
+        asset_type=asset_type,
+    )
     
     # Use config default if not specified
     if top_n_features is None:
@@ -183,7 +224,7 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
         print(f"Found {len(correlated_pairs)} highly correlated feature pairs:")
         for feat1, feat2, corr in correlated_pairs:
             print(f"  {feat1} and {feat2}: {corr:.3f}")
-        
+
         # Save collinearity results
         with open(os.path.join(audit_dir, 'collinearity_analysis.txt'), 'w') as f:
             f.write("Highly Correlated Feature Pairs:\n")
@@ -192,37 +233,48 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
                 f.write(f"{feat1} and {feat2}: {corr:.3f}\n")
     else:
         print("No highly correlated features found.")
-    
-    # Train model for feature importance analysis
-    print(f"\n--- Training {model_type} for Feature Importance ---")
-    model = ModelFactory.create_model(model_type)
-    model.train(X_train, y_train)
-    
-    # Perform feature audit
-    print(f"--- Running Permutation Importance Analysis ---")
-    train_imp, test_imp, top_features = audit_features(
-        model,
-        X_train,
-        y_train,
-        X_test,
-        y_test,
-        n_repeats=config.FEATURE_AUDIT_N_REPEATS,
-        n_top_features=top_n_features,
-        random_state=config.RANDOM_STATE
-    )
-    
-    print(f"\nTop {len(top_features)} features selected:")
-    for i, feature in enumerate(top_features, 1):
-        importance = test_imp[test_imp['feature'] == feature]['importance_mean'].iloc[0]
-        print(f"  {i:2d}. {feature}: {importance:.4f}")
-    
-    # Save audit results
-    train_imp.to_csv(os.path.join(audit_dir, 'train_importance.csv'), index=False)
-    test_imp.to_csv(os.path.join(audit_dir, 'test_importance.csv'), index=False)
-    
-    with open(os.path.join(audit_dir, 'top_features.txt'), 'w') as f:
-        for feature in top_features:
-            f.write(f"{feature}\n")
+
+    momentum_strategies = {
+        'bb_rsi_adx', 'tema', 'quod', 'jfk_dsrsi', 'mpo_3tf'
+    }
+    if model_type in momentum_strategies:
+        print(f"Feature audit not applicable for momentum strategy {model_type}")
+        audit_results = {}
+        top_features = []
+        if audit_only:
+            return top_features, audit_results
+        return X_train, X_test, y_train, y_test, audit_results
+    else:
+        # Train model for feature importance analysis
+        print(f"\n--- Training {model_type} for Feature Importance ---")
+        model = ModelFactory.create_model(model_type)
+        model.train(X_train, y_train)
+
+        # Perform feature audit
+        print(f"--- Running Permutation Importance Analysis ---")
+        train_imp, test_imp, top_features = audit_features(
+            model,
+            X_train,
+            y_train,
+            X_test,
+            y_test,
+            n_repeats=config.FEATURE_AUDIT_N_REPEATS,
+            n_top_features=top_n_features,
+            random_state=config.RANDOM_STATE
+        )
+
+        print(f"\nTop {len(top_features)} features selected:")
+        for i, feature in enumerate(top_features, 1):
+            importance = test_imp[test_imp['feature'] == feature]['importance_mean'].iloc[0]
+            print(f"  {i:2d}. {feature}: {importance:.4f}")
+
+        # Save audit results
+        train_imp.to_csv(os.path.join(audit_dir, 'train_importance.csv'), index=False)
+        test_imp.to_csv(os.path.join(audit_dir, 'test_importance.csv'), index=False)
+
+        with open(os.path.join(audit_dir, 'top_features.txt'), 'w') as f:
+            for feature in top_features:
+                f.write(f"{feature}\n")
     
     # Create feature importance plot
     plt.figure(figsize=(12, 8))
@@ -274,10 +326,11 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
     
     return X_train_pruned, X_test_pruned, y_train, y_test, audit_results
 
-def run_strategy_comparison(data_path, output_dir='results_comparison', 
+def run_strategy_comparison(data_path, output_dir='results_comparison',
                            train_end_date=None, symbol='SPY', use_optimized_params=False,
-                           run_feature_audit_flag=False, audit_model='random_forest', 
-                           top_n_features=None, include_momentum=False, timeframe='daily'):
+                           run_feature_audit_flag=False, audit_model='random_forest',
+                           top_n_features=None, include_momentum=False, timeframe='daily',
+                           train_data=None, test_data=None, asset_type=None):
     """
     Run comparison of different strategies/models.
     
@@ -315,7 +368,9 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
     if run_feature_audit_flag:
         print("=== Feature Audit Phase ===")
         top_features, audit_results = run_feature_audit(
-            data_path, output_dir, audit_model, top_n_features, audit_only=True, symbol=symbol, timeframe=timeframe
+            data_path, output_dir, audit_model, top_n_features, audit_only=True,
+            symbol=symbol, timeframe=timeframe, train_data=train_data,
+            test_data=test_data, asset_type=asset_type
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
         
@@ -325,7 +380,14 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
                 f.write(f"{feature}\n")
     
     # Load data
-    df = load_data(data_path, symbol=symbol, timeframe=timeframe)
+    df = load_data(
+        data_path,
+        symbol=symbol,
+        timeframe=timeframe,
+        train_data=train_data,
+        test_data=test_data,
+        asset_type=asset_type,
+    )
     
     # Define training and testing periods
     if train_end_date is not None:
@@ -343,7 +405,7 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
     
     # Get strategy configurations
     strategy_configs = get_strategy_configs(use_optimized_params, include_momentum=include_momentum, timeframe=timeframe)
-    
+
     # Set symbol for all configs and feature audit settings
     for config in strategy_configs:
         config['symbol'] = symbol
@@ -354,7 +416,7 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
             config['use_feature_pruning'] = True
             config['audit_model'] = audit_model
             config['top_n_features'] = top_n_features or config.TOP_N_FEATURES
-    
+
     # Run strategies
     results = {}
     equity_curves = []
@@ -382,12 +444,12 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
             strategy_type = 'quod'
         else:
             strategy_type = 'trend_following'
-            
+
         # Use StrategyRegistry to get strategy instance
         strategy = StrategyRegistry.get_strategy(strategy_type, config)
 
         # Run backtest
-        backtest_results = strategy.backtest(df, train_data, test_data, timeframe)
+        backtest_results = strategy.backtest(df, train_df, test_df, timeframe)
 
         # Store results
         results[config['name']] = backtest_results
@@ -600,7 +662,8 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
                        calibrate=False, use_optimized_params=False,
                        run_feature_audit_flag=False, audit_model='random_forest',
                        top_n_features=None, timeframe='daily',
-                       performance_window=None, switch_cooldown=None):
+                       performance_window=None, switch_cooldown=None,
+                       train_data=None, test_data=None, asset_type=None):
     """
     Run a single strategy with specified parameters.
     
@@ -646,27 +709,36 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
     if run_feature_audit_flag:
         print("=== Feature Audit Phase ===")
         top_features, audit_results = run_feature_audit(
-            data_path, output_dir, audit_model, top_n_features, audit_only=True, symbol=symbol, timeframe=timeframe
+            data_path, output_dir, audit_model, top_n_features, audit_only=True,
+            symbol=symbol, timeframe=timeframe, train_data=train_data,
+            test_data=test_data, asset_type=asset_type
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
     
     # Load data
-    df = load_data(data_path, symbol=symbol, timeframe=timeframe)
+    df = load_data(
+        data_path,
+        symbol=symbol,
+        timeframe=timeframe,
+        train_data=train_data,
+        test_data=test_data,
+        asset_type=asset_type,
+    )
     
     # Define training and testing periods
     if train_end_date is not None:
         train_end_date = pd.to_datetime(train_end_date)
-        train_data = df[df.index <= train_end_date]
-        test_data = df[df.index > train_end_date]
+        train_df = df[df.index <= train_end_date]
+        test_df = df[df.index > train_end_date]
     else:
         # Use 70% of data for training
         train_size = int(len(df) * 0.7)
-        train_data = df.iloc[:train_size]
-        test_data = df.iloc[train_size:]
-    
+        train_df = df.iloc[:train_size]
+        test_df = df.iloc[train_size:]
+
     # Print training and testing data info
-    print(f"Training data: {len(train_data)} rows ({train_data.index[0]} to {train_data.index[-1]})")
-    print(f"Testing data: {len(test_data)} rows ({test_data.index[0]} to {test_data.index[-1]})")
+    print(f"Training data: {len(train_df)} rows ({train_df.index[0]} to {train_df.index[-1]})")
+    print(f"Testing data: {len(test_df)} rows ({test_df.index[0]} to {test_df.index[-1]})")
     
     # Check if model_type is a momentum strategy or meta-strategy
     momentum_strategies = ['bb_rsi_adx', 'tema', 'quod', 'jfk_dsrsi', 'mpo_3tf', 'meta_strategy']
@@ -792,7 +864,7 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
     strategy = StrategyRegistry.get_strategy(strategy_type, config)
     
     # Run backtest
-    results = strategy.backtest(df, train_data, test_data, timeframe)
+    results = strategy.backtest(df, train_df, test_df, timeframe)
     
     # Save model/strategy
     # For momentum strategies, this saves configuration only
@@ -915,6 +987,14 @@ def parse_arguments():
     
     parser.add_argument('--symbol', type=str, default='SPY',
                         help='Trading symbol (default: SPY)')
+
+    parser.add_argument('--asset-type', type=str, choices=['STOCK', 'INDEX'], default=None,
+                        help='Asset type prefix in data files (e.g., STOCK or INDEX)')
+
+    parser.add_argument('--train-data', type=str, default=None,
+                        help='Explicit path to training data file')
+    parser.add_argument('--test-data', type=str, default=None,
+                        help='Explicit path to testing data file')
     
     parser.add_argument('--calibrate', action='store_true',
                         help='Use probability calibration for Decision Tree and Random Forest models')
@@ -930,8 +1010,8 @@ def parse_arguments():
     parser.add_argument('--feature-audit', action='store_true',
                         help='Perform feature importance audit before running strategies')
     
-    parser.add_argument('--audit-model', type=str, 
-                        choices=['decision_tree', 'random_forest', 'xgboost'], 
+    parser.add_argument('--audit-model', type=str,
+                        choices=['decision_tree', 'random_forest', 'xgboost', 'bb_rsi_adx', 'tema', 'quod', 'jfk_dsrsi', 'mpo_3tf'],
                         default='random_forest',
                         help='Model type for feature importance evaluation (default: random_forest)')
     
@@ -967,7 +1047,10 @@ def main():
             top_n_features=args.top_features,
             audit_only=True,
             symbol=args.symbol,
-            timeframe=args.timeframe
+            timeframe=args.timeframe,
+            train_data=args.train_data,
+            test_data=args.test_data,
+            asset_type=args.asset_type,
         )
     elif args.mode == 'single':
         run_single_strategy(
@@ -984,7 +1067,10 @@ def main():
             top_n_features=args.top_features,
             timeframe=args.timeframe,
             performance_window=args.performance_window,
-            switch_cooldown=args.switch_cooldown
+            switch_cooldown=args.switch_cooldown,
+            train_data=args.train_data,
+            test_data=args.test_data,
+            asset_type=args.asset_type,
         )
     else:  # compare mode
         run_strategy_comparison(
@@ -997,7 +1083,10 @@ def main():
             audit_model=args.audit_model,
             top_n_features=args.top_features,
             include_momentum=args.include_momentum,
-            timeframe=args.timeframe
+            timeframe=args.timeframe,
+            train_data=args.train_data,
+            test_data=args.test_data,
+            asset_type=args.asset_type,
         )
 
 if __name__ == "__main__":

--- a/tests/test_jfk_dsrsi_adapter.py
+++ b/tests/test_jfk_dsrsi_adapter.py
@@ -1,0 +1,41 @@
+import unittest
+import pandas as pd
+import numpy as np
+from src.strategies.adapters.jfk_dsrsi_adapter import JFKDSRSIAdapter
+
+class TestJFKDSRSIAdapter(unittest.TestCase):
+    def setUp(self):
+        dates = pd.date_range('2023-01-01', periods=200, freq='5T')
+        prices = np.linspace(100, 110, len(dates)) + np.random.normal(0, 0.5, len(dates))
+        self.data = pd.DataFrame({
+            'open': prices * 0.99,
+            'high': prices * 1.01,
+            'low': prices * 0.98,
+            'close': prices,
+            'volume': np.random.randint(1_000, 5_000, len(dates))
+        }, index=dates)
+        self.config = {'symbol': 'TEST', 'timeframe': '5min'}
+
+    def test_initialization(self):
+        adapter = JFKDSRSIAdapter()
+        adapter.initialize(self.config)
+        self.assertEqual(adapter.dsrsi_length, 14)
+        self.assertEqual(adapter.kps_length, 14)
+
+    def test_signal_generation(self):
+        adapter = JFKDSRSIAdapter()
+        adapter.initialize(self.config)
+        features, _, dates = adapter.generate_features(self.data)
+        signals = adapter.generate_signals(features, None, dates)
+        self.assertIn('signal', signals.columns)
+        self.assertTrue(set(signals['signal'].unique()).issubset({-1,0,1}))
+
+    def test_backtest(self):
+        adapter = JFKDSRSIAdapter()
+        adapter.initialize(self.config)
+        results = adapter.backtest(self.data)
+        self.assertIn('total_return', results)
+        self.assertIn('trades', results)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mpo3tf_adapter.py
+++ b/tests/test_mpo3tf_adapter.py
@@ -1,0 +1,41 @@
+import unittest
+import pandas as pd
+import numpy as np
+from src.strategies.adapters.mpo_3tf_adapter import MPO3TFAdapter
+
+class TestMPO3TFAdapter(unittest.TestCase):
+    def setUp(self):
+        dates = pd.date_range('2023-01-01', periods=200, freq='1T')
+        prices = np.linspace(50, 55, len(dates)) + np.random.normal(0, 0.2, len(dates))
+        self.data = pd.DataFrame({
+            'open': prices * 0.99,
+            'high': prices * 1.01,
+            'low': prices * 0.98,
+            'close': prices,
+            'volume': np.random.randint(500, 2000, len(dates))
+        }, index=dates)
+        self.config = {'symbol': 'TEST', 'timeframe': '1min'}
+
+    def test_initialization(self):
+        adapter = MPO3TFAdapter()
+        adapter.initialize(self.config)
+        self.assertEqual(adapter.rsi_period, 14)
+        self.assertEqual(adapter.atr_length, 14)
+
+    def test_signal_generation(self):
+        adapter = MPO3TFAdapter()
+        adapter.initialize(self.config)
+        features, _, dates = adapter.generate_features(self.data)
+        signals = adapter.generate_signals(features, None, dates)
+        self.assertIn('signal', signals.columns)
+        self.assertTrue(set(signals['signal'].unique()).issubset({-1,0,1}))
+
+    def test_backtest(self):
+        adapter = MPO3TFAdapter()
+        adapter.initialize(self.config)
+        results = adapter.backtest(self.data)
+        self.assertIn('total_return', results)
+        self.assertIn('trades', results)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Normalize timezones across loaders and add flexible file discovery with `--train-data`, `--test-data`, and `--asset-type` options
- Integrate JFK-DSRSI and MPO-3TF strategies into configs, meta-strategy, and hybrid momentum flows
- Document SPX data usage and provide unit tests for new momentum adapters

## Testing
- `pip install -r requirements-testing.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dfa2a19c48330bbd92f28064fc1ac