### PR TITLE
Fix backtest cost check and update workflow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,16 @@ python strategy_runner.py --data data/raw --model random_forest --timeframe 5min
 The JFK-DSRSI and MPO-3TF momentum strategies support both SPY and SPX symbols. Use the new CLI options to specify asset type and custom data files:
 
 ```bash
+# JFK-DSRSI example (SPX index)
 python strategy_runner.py --data data/raw --model jfk_dsrsi --timeframe 5min \
+    --symbol SPX --asset-type INDEX
+
+# MPO-3TF example (SPY stock)
+python strategy_runner.py --data data/raw --model mpo_3tf --timeframe 5min \
+    --symbol SPY --asset-type STOCK
+
+# Both strategies also support 1-minute data
+python strategy_runner.py --data data/raw --model jfk_dsrsi --timeframe 1min \
     --symbol SPX --asset-type INDEX
 ```
 
@@ -106,6 +115,12 @@ python strategy_runner.py --data data/raw --model xgboost --mode single --output
 
 # Test Stacking Ensemble
 python strategy_runner.py --data data/raw --model stacking --mode single --output test_stacking
+
+# Test JFK-DSRSI momentum (SPX example)
+python strategy_runner.py --data data/raw --model jfk_dsrsi --timeframe 5min --symbol SPX --asset-type INDEX --output test_jfk
+
+# Test MPO-3TF momentum (SPY example)
+python strategy_runner.py --data data/raw --model mpo_3tf --timeframe 5min --symbol SPY --output test_mpo
 ```
 
 **Expected Results:**

--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -109,6 +109,8 @@ class BacktestEngine:
                     continue
                     
                 price = price_data.loc[date, 'close']
+                if isinstance(price, pd.Series):
+                    price = price.iloc[0]
                 
                 # Process signal
                 if signal == 1 and symbol not in self.positions:  # Buy

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -210,6 +210,9 @@ def engineer_features(df, lookback_period=10, timeframe: str = 'daily'):
             'volatility_5', 'lag_return_1', 'lag_return_3'
         ])
 
+    df_features.replace([np.inf, -np.inf], np.nan, inplace=True)
+    df_features.dropna(inplace=True)
+
     # Extract features
     X = df_features[features]
     

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -481,7 +481,7 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         plt.figure(figsize=(12, 8))
 
         # Add buy and hold equity curve for reference
-        buy_hold = (test_data['close'] / test_data['close'].iloc[0])
+        buy_hold = (test_df['close'] / test_df['close'].iloc[0])
         plt.plot(buy_hold.index, buy_hold, label='Buy & Hold', linestyle='--')
 
         # Plot strategy equity curves
@@ -889,7 +889,7 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         plt.plot(equity.index, equity / equity.iloc[0], label=config['name'])
         
         # Buy and hold reference
-        buy_hold = (test_data['close'] / test_data['close'].iloc[0])
+        buy_hold = (test_df['close'] / test_df['close'].iloc[0])
         plt.plot(buy_hold.index, buy_hold, label='Buy & Hold', linestyle='--')
         
         plt.title(f'{config["name"]} Strategy vs Buy & Hold')


### PR DESCRIPTION
## Summary
- prevent Series comparison in backtest engine by selecting scalar price
- drop infinite feature values to avoid training failures
- fix buy-hold reference to use internal test dataframe
- document JFK-DSRSI and MPO-3TF usage in README and smoke tests

## Testing
- `pytest`
- `python strategy_runner.py --data data/raw --model random_forest --timeframe 5min --output rf_5min_test --train-end 2023-01-01 --symbol SPY` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689e028fa5b083309cfb9332fc6094ee