### PR TITLE
Refactor thresholds and apply transaction costs

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,10 @@ INITIAL_CAPITAL = 100000  # Initial capital for backtesting
 COMMISSION_RATE = 0.0005  # Commission rate per trade (0.05%)
 SLIPPAGE_RATE = 0.0001  # Slippage rate per trade (0.01%)
 
+# Signal threshold settings
+BUY_THRESHOLD = 0.55
+SELL_THRESHOLD = 0.45
+
 # Risk management settings
 MAX_POSITION_SIZE = 0.05  # Maximum position size as fraction of total capital
 MAX_PORTFOLIO_ALLOCATION = 0.5  # Maximum portfolio allocation

--- a/docs/operational_workflow.md
+++ b/docs/operational_workflow.md
@@ -1,0 +1,56 @@
+# Operational Workflow
+
+This document outlines the recommended workflow for running and evaluating strategies
+in the DecisionTree project after the latest updates.
+
+## 1. Prepare Data
+- Place historical CSV files under the `data/` directory.
+- For intraday tests, ensure 5-minute or 1-minute files follow the naming
+  conventions used by `strategy_runner.py`.
+
+## 2. Optional Feature Audit
+```
+python strategy_runner.py --mode audit --data <data_path> --output <out_dir> \
+    --audit-model random_forest --timeframe 5min
+```
+This generates feature importance reports in `<out_dir>/feature_audit` without
+splitting data manually.
+
+## 3. Run Strategy Comparison
+```
+python strategy_runner.py --mode comparison --data <data_path> \
+    --include-momentum --timeframe 5min
+```
+This evaluates multiple strategies using the new default thresholds (0.55/0.45)
+and applies commission and slippage from `config.py` to momentum strategies.
+
+## 4. Run a Single Strategy
+```
+python strategy_runner.py --mode single --data <data_path> \
+    --model-type random_forest --timeframe 5min
+```
+The script automatically splits data 70/30 for training and testing and uses the
+central `ThresholdManager` for signal generation.
+
+## 5. Retrain and Optimise Models
+Use `optimize_hyperparameters.py` for Sharpe-ratio driven tuning:
+```
+python optimize_hyperparameters.py --model random_forest --timeframe 5min
+```
+Store resulting parameters in `data/hyperparameters/` for reuse.
+
+## 6. Testing
+Run targeted tests to verify critical components:
+```
+pytest tests/test_threshold_manager.py
+```
+Additional tests reside under `tests/` and can be executed with `pytest`.
+
+## 7. Configuration
+Adjust thresholds and transaction cost settings in `config.py`:
+- `BUY_THRESHOLD` / `SELL_THRESHOLD`
+- `COMMISSION_RATE` / `SLIPPAGE_RATE`
+
+These values are consumed by `ThresholdManager` and momentum adapters during
+backtests.
+

--- a/src/backtesting/signal_generation.py
+++ b/src/backtesting/signal_generation.py
@@ -4,7 +4,7 @@ Module for generating trading signals from model predictions.
 """
 
 import pandas as pd
-from src.strategies.base_strategy import BUY_THRESHOLD, SELL_THRESHOLD
+from src.utils.threshold_manager import ThresholdManager
 
 
 def generate_signals(model, X, dates, symbol="SPY"):
@@ -34,10 +34,13 @@ def generate_signals(model, X, dates, symbol="SPY"):
     if not isinstance(dates, pd.Series):
         dates = pd.Series(dates)
 
-    # Create signals DataFrame using global thresholds
+    # Create signals DataFrame using threshold manager
+    tm = ThresholdManager()
+    buy_threshold, sell_threshold = tm.get_thresholds()
+
     signals = []
     for i in range(len(X)):
-        if proba[i] > BUY_THRESHOLD:  # Buy signal
+        if proba[i] > buy_threshold:  # Buy signal
             signals.append(
                 {
                     "date": dates.iloc[i],
@@ -46,7 +49,7 @@ def generate_signals(model, X, dates, symbol="SPY"):
                     "probability": proba[i],
                 }
             )
-        elif proba[i] < SELL_THRESHOLD:  # Sell signal
+        elif proba[i] < sell_threshold:  # Sell signal
             signals.append(
                 {
                     "date": dates.iloc[i],

--- a/src/strategies/adapters/bbrsiadx_adapter.py
+++ b/src/strategies/adapters/bbrsiadx_adapter.py
@@ -20,6 +20,7 @@ from src.features.indicators import (
     calculate_adx, calculate_supertrend
 )
 from src.features.multi_timeframe_features import MultiTimeframeAggregator
+import config
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -427,6 +428,11 @@ class BBRSIADXAdapter(BaseStrategy):
         # Calculate returns
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
+
+        commission = self.config.get('commission', config.COMMISSION_RATE)
+        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        trade_changes = signals['signal'].diff().abs().fillna(0)
+        returns -= trade_changes * (commission + slippage)
         
         # Determine annualization factor based on timeframe
         timeframe = self.config.get('primary_timeframe', '1h')

--- a/src/strategies/adapters/jfk_dsrsi_adapter.py
+++ b/src/strategies/adapters/jfk_dsrsi_adapter.py
@@ -3,9 +3,11 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
+import logging
 
 from src.strategies.base_strategy import BaseStrategy
 from src.features.indicators import calculate_rsi, calculate_atr
+import config
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +119,11 @@ class JFKDSRSIAdapter(BaseStrategy):
         aligned_prices = prices.loc[signals.index]
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
+
+        commission = self.config.get('commission', config.COMMISSION_RATE)
+        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        trade_changes = signals['signal'].diff().abs().fillna(0)
+        returns -= trade_changes * (commission + slippage)
 
         timeframe = self.config.get('timeframe', '5min') if hasattr(self, 'config') and self.config else '5min'
         if timeframe in ['5min', '5T', '5m']:

--- a/src/strategies/adapters/mpo_3tf_adapter.py
+++ b/src/strategies/adapters/mpo_3tf_adapter.py
@@ -7,6 +7,7 @@ import pandas as pd
 from src.strategies.base_strategy import BaseStrategy
 from src.features.indicators import calculate_rsi, calculate_atr
 from src.features.multi_timeframe_features import MultiTimeframeAggregator
+import config
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,11 @@ class MPO3TFAdapter(BaseStrategy):
         aligned_prices = prices.loc[signals.index]
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
+
+        commission = self.config.get('commission', config.COMMISSION_RATE)
+        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        trade_changes = signals['signal'].diff().abs().fillna(0)
+        returns -= trade_changes * (commission + slippage)
 
         timeframe = self.config.get('timeframe', '1min') if hasattr(self, 'config') and self.config else '1min'
         if timeframe in ['1min', '1T', '1m']:

--- a/src/strategies/adapters/quod_adapter.py
+++ b/src/strategies/adapters/quod_adapter.py
@@ -17,6 +17,7 @@ from src.strategies.base_strategy import BaseStrategy
 from src.strategies.order_management import OrderManagementSystem, OrderType
 from src.features.indicators import calculate_stochastic, calculate_atr
 from src.features.multi_timeframe_features import MultiTimeframeAggregator
+import config
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -533,6 +534,11 @@ class QuodAdapter(BaseStrategy):
         # Calculate returns
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
+
+        commission = self.config.get('commission', config.COMMISSION_RATE)
+        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        trade_changes = signals['signal'].diff().abs().fillna(0)
+        returns -= trade_changes * (commission + slippage)
         
         # Determine annualization factor based on timeframe
         timeframe = self.config.get('primary_timeframe', '5T')

--- a/src/strategies/adapters/tema_adapter.py
+++ b/src/strategies/adapters/tema_adapter.py
@@ -18,6 +18,7 @@ from src.features.indicators import (
     calculate_tema, calculate_atr, calculate_adx, calculate_cmo
 )
 from src.features.multi_timeframe_features import MultiTimeframeAggregator
+import config
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -450,6 +451,11 @@ class TEMAAdapter(BaseStrategy):
         # Calculate returns
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
+
+        commission = self.config.get('commission', config.COMMISSION_RATE)
+        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        trade_changes = signals['signal'].diff().abs().fillna(0)
+        returns -= trade_changes * (commission + slippage)
         
         # Determine annualization factor based on timeframe
         timeframe = self.config.get('primary_timeframe', '1h')

--- a/src/strategies/base_strategy.py
+++ b/src/strategies/base_strategy.py
@@ -5,23 +5,8 @@ Base strategy interface for trading strategies.
 from abc import ABC, abstractmethod
 import numpy as np
 import pandas as pd
-import warnings
 from typing import List, Dict, Tuple, Optional, Union
 from src.utils.threshold_manager import ThresholdManager
-
-# Backward compatibility constants (DEPRECATED)
-# These constants are deprecated as of v0.2 - use ThresholdManager instead
-BUY_THRESHOLD = 0.65
-SELL_THRESHOLD = 0.35
-
-# Issue deprecation warning when these constants are imported
-warnings.warn(
-    "BUY_THRESHOLD and SELL_THRESHOLD constants are deprecated. "
-    "Use ThresholdManager.get_thresholds() instead for adaptive threshold support. "
-    "Legacy constants will be removed in a future version.",
-    DeprecationWarning,
-    stacklevel=2
-)
 
 class BaseStrategy(ABC):
     """

--- a/src/strategies/regime_adaptive_strategy.py
+++ b/src/strategies/regime_adaptive_strategy.py
@@ -47,11 +47,9 @@ class RegimeAdaptiveStrategy(TrendFollowingStrategy):
         super().initialize(config)
         
         # ---- Default probability thresholds ----
-        # Use global constants to maintain a single source of truth
-        from .base_strategy import BUY_THRESHOLD, SELL_THRESHOLD
-        self.buy_threshold = BUY_THRESHOLD
-        self.sell_threshold = SELL_THRESHOLD
-        
+        # Retrieve initial thresholds from ThresholdManager
+        self.buy_threshold, self.sell_threshold = self.get_thresholds()
+
         # For backward compatibility with helper methods that still
         # expect a single attribute
         self.threshold = (self.buy_threshold, self.sell_threshold)

--- a/src/strategies/trend_following.py
+++ b/src/strategies/trend_following.py
@@ -4,7 +4,7 @@ Trend following strategy using ensemble models.
 
 import pandas as pd
 import numpy as np
-from .base_strategy import BaseStrategy, BUY_THRESHOLD, SELL_THRESHOLD
+from .base_strategy import BaseStrategy
 from src.engines.model_engine import ModelEngine
 from src.engines.signal_engine import SignalEngine
 from src.features.feature_engineering import engineer_features

--- a/src/utils/threshold_manager.py
+++ b/src/utils/threshold_manager.py
@@ -10,8 +10,8 @@ import numpy as np
 from src.utils.adaptive_thresholds import are_adaptive_thresholds_needed, calculate_adaptive_thresholds
 
 # Global threshold constants
-DEFAULT_BUY_THRESHOLD = 0.65
-DEFAULT_SELL_THRESHOLD = 0.35
+DEFAULT_BUY_THRESHOLD = 0.55
+DEFAULT_SELL_THRESHOLD = 0.45
 
 class ThresholdManager:
     """

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -169,9 +169,6 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
         data_path,
         symbol=symbol,
         timeframe=timeframe,
-        train_data=train_data,
-        test_data=test_data,
-        asset_type=asset_type,
     )
     
     # Use config default if not specified
@@ -369,8 +366,7 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         print("=== Feature Audit Phase ===")
         top_features, audit_results = run_feature_audit(
             data_path, output_dir, audit_model, top_n_features, audit_only=True,
-            symbol=symbol, timeframe=timeframe, train_data=train_data,
-            test_data=test_data, asset_type=asset_type
+            symbol=symbol, timeframe=timeframe
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
         
@@ -449,7 +445,7 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         strategy = StrategyRegistry.get_strategy(strategy_type, config)
 
         # Run backtest
-        backtest_results = strategy.backtest(df, train_df, test_df, timeframe)
+        backtest_results = strategy.backtest(df, train_data, test_data, timeframe)
 
         # Store results
         results[config['name']] = backtest_results
@@ -481,7 +477,7 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         plt.figure(figsize=(12, 8))
 
         # Add buy and hold equity curve for reference
-        buy_hold = (test_df['close'] / test_df['close'].iloc[0])
+        buy_hold = (test_data['close'] / test_data['close'].iloc[0])
         plt.plot(buy_hold.index, buy_hold, label='Buy & Hold', linestyle='--')
 
         # Plot strategy equity curves
@@ -710,8 +706,7 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         print("=== Feature Audit Phase ===")
         top_features, audit_results = run_feature_audit(
             data_path, output_dir, audit_model, top_n_features, audit_only=True,
-            symbol=symbol, timeframe=timeframe, train_data=train_data,
-            test_data=test_data, asset_type=asset_type
+            symbol=symbol, timeframe=timeframe
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
     
@@ -1048,9 +1043,6 @@ def main():
             audit_only=True,
             symbol=args.symbol,
             timeframe=args.timeframe,
-            train_data=args.train_data,
-            test_data=args.test_data,
-            asset_type=args.asset_type,
         )
     elif args.mode == 'single':
         run_single_strategy(

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -132,8 +132,9 @@ def load_data(data_path, symbol='SPY', timeframe='daily', train_data=None, test_
     
     return df
 
-def run_feature_audit(data_path, output_dir, model_type='random_forest', 
-                     top_n_features=None, audit_only=False, symbol='SPY', timeframe='daily'):
+def run_feature_audit(data_path, output_dir, model_type='random_forest',
+                     top_n_features=None, audit_only=False, symbol='SPY', timeframe='daily',
+                     train_data=None, test_data=None, asset_type=None):
     """
     Run feature importance audit on the data.
     
@@ -169,6 +170,9 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
         data_path,
         symbol=symbol,
         timeframe=timeframe,
+        train_data=train_data,
+        test_data=test_data,
+        asset_type=asset_type,
     )
     
     # Use config default if not specified
@@ -366,7 +370,8 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         print("=== Feature Audit Phase ===")
         top_features, audit_results = run_feature_audit(
             data_path, output_dir, audit_model, top_n_features, audit_only=True,
-            symbol=symbol, timeframe=timeframe
+            symbol=symbol, timeframe=timeframe,
+            train_data=train_data, test_data=test_data, asset_type=asset_type
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
         
@@ -706,7 +711,8 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         print("=== Feature Audit Phase ===")
         top_features, audit_results = run_feature_audit(
             data_path, output_dir, audit_model, top_n_features, audit_only=True,
-            symbol=symbol, timeframe=timeframe
+            symbol=symbol, timeframe=timeframe,
+            train_data=train_data, test_data=test_data, asset_type=asset_type
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
     
@@ -723,17 +729,17 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
     # Define training and testing periods
     if train_end_date is not None:
         train_end_date = pd.to_datetime(train_end_date)
-        train_df = df[df.index <= train_end_date]
-        test_df = df[df.index > train_end_date]
+        train_data = df[df.index <= train_end_date]
+        test_data = df[df.index > train_end_date]
     else:
         # Use 70% of data for training
         train_size = int(len(df) * 0.7)
-        train_df = df.iloc[:train_size]
-        test_df = df.iloc[train_size:]
+        train_data = df.iloc[:train_size]
+        test_data = df.iloc[train_size:]
 
     # Print training and testing data info
-    print(f"Training data: {len(train_df)} rows ({train_df.index[0]} to {train_df.index[-1]})")
-    print(f"Testing data: {len(test_df)} rows ({test_df.index[0]} to {test_df.index[-1]})")
+    print(f"Training data: {len(train_data)} rows ({train_data.index[0]} to {train_data.index[-1]})")
+    print(f"Testing data: {len(test_data)} rows ({test_data.index[0]} to {test_data.index[-1]})")
     
     # Check if model_type is a momentum strategy or meta-strategy
     momentum_strategies = ['bb_rsi_adx', 'tema', 'quod', 'jfk_dsrsi', 'mpo_3tf', 'meta_strategy']
@@ -859,7 +865,7 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
     strategy = StrategyRegistry.get_strategy(strategy_type, config)
     
     # Run backtest
-    results = strategy.backtest(df, train_df, test_df, timeframe)
+    results = strategy.backtest(df, train_data, test_data, timeframe)
     
     # Save model/strategy
     # For momentum strategies, this saves configuration only
@@ -884,7 +890,7 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         plt.plot(equity.index, equity / equity.iloc[0], label=config['name'])
         
         # Buy and hold reference
-        buy_hold = (test_df['close'] / test_df['close'].iloc[0])
+        buy_hold = (test_data['close'] / test_data['close'].iloc[0])
         plt.plot(buy_hold.index, buy_hold, label='Buy & Hold', linestyle='--')
         
         plt.title(f'{config["name"]} Strategy vs Buy & Hold')
@@ -1043,6 +1049,9 @@ def main():
             audit_only=True,
             symbol=args.symbol,
             timeframe=args.timeframe,
+            train_data=args.train_data,
+            test_data=args.test_data,
+            asset_type=args.asset_type,
         )
     elif args.mode == 'single':
         run_single_strategy(

--- a/test_probability_calibration.py
+++ b/test_probability_calibration.py
@@ -7,14 +7,12 @@ import numpy as np
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 from src.models.model_factory import ModelFactory
-from src.strategies.base_strategy import BUY_THRESHOLD, SELL_THRESHOLD
 
 def main():
     print('Creating test data...')
     X, y = make_classification(n_samples=1000, n_features=20, random_state=42)
     X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
 
-    print(f'\nGlobal thresholds: buy={BUY_THRESHOLD}, sell={SELL_THRESHOLD}')
 
     print('\nTesting DecisionTree with calibration...')
     dt = ModelFactory.create_model('decision_tree', calibrate=True)

--- a/tests/test_threshold_manager.py
+++ b/tests/test_threshold_manager.py
@@ -1,0 +1,15 @@
+from src.utils.threshold_manager import ThresholdManager
+
+
+def test_default_thresholds():
+    tm = ThresholdManager()
+    buy, sell = tm.get_thresholds()
+    assert buy == 0.55
+    assert sell == 0.45
+
+
+def test_prob_to_signal_applies_thresholds():
+    tm = ThresholdManager()
+    assert tm.prob_to_signal(0.6) == 1
+    assert tm.prob_to_signal(0.4) == -1
+    assert tm.prob_to_signal(0.5) == 0


### PR DESCRIPTION
## Summary
- fix feature-audit invocation and undefined train/test variables in `strategy_runner.py`
- remove deprecated threshold constants and lower default buy/sell levels to 0.55/0.45
- apply commission and slippage in momentum adapters and document operational workflow

## Testing
- `pytest tests/test_threshold_manager.py tests/test_momentum_adapters.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_689e60fec93c833095bff8c831048e5d