### PR TITLE
Fix feature audit arguments and transformer loss shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ pip install -r requirements-testing.txt  # install test dependencies
 python strategy_runner.py --data data/raw --model random_forest --mode single --output quick_test
 ```
 
+### Configuration Highlights
+- Default confidence thresholds: **BUY 0.55**, **SELL 0.45**
+- Adaptive thresholds enabled by default (`USE_ADAPTIVE_THRESHOLDS='always'`)
+
 ## 📊 Comprehensive System Testing Guide
 
 This guide provides step-by-step testing procedures to validate all system capabilities. Tests progress from basic functionality to advanced features.

--- a/src/models/transformer/transformer_wrapper.py
+++ b/src/models/transformer/transformer_wrapper.py
@@ -212,7 +212,7 @@ class TransformerModelWrapper:
                 try:
                     # Forward pass
                     outputs = self.model(batch_X)
-                    loss = criterion(outputs.squeeze(), batch_y.float())
+                    loss = criterion(outputs.view(-1), batch_y.float())
                     
                     # Backward pass
                     optimizer.zero_grad()

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -133,8 +133,7 @@ def load_data(data_path, symbol='SPY', timeframe='daily', train_data=None, test_
     return df
 
 def run_feature_audit(data_path, output_dir, model_type='random_forest',
-                     top_n_features=None, audit_only=False, symbol='SPY', timeframe='daily',
-                     train_data=None, test_data=None, asset_type=None):
+                     top_n_features=None, audit_only=False, symbol='SPY', timeframe='daily'):
     """
     Run feature importance audit on the data.
     
@@ -152,7 +151,7 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
         If True, only perform audit without affecting main workflow
     symbol : str, default='SPY'
         Trading symbol
-        
+
     Returns:
     --------
     tuple
@@ -170,9 +169,6 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
         data_path,
         symbol=symbol,
         timeframe=timeframe,
-        train_data=train_data,
-        test_data=test_data,
-        asset_type=asset_type,
     )
     
     # Use config default if not specified
@@ -371,7 +367,6 @@ def run_strategy_comparison(data_path, output_dir='results_comparison',
         top_features, audit_results = run_feature_audit(
             data_path, output_dir, audit_model, top_n_features, audit_only=True,
             symbol=symbol, timeframe=timeframe,
-            train_data=train_data, test_data=test_data, asset_type=asset_type
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
         
@@ -712,7 +707,6 @@ def run_single_strategy(data_path, model_type='random_forest', output_dir='resul
         top_features, audit_results = run_feature_audit(
             data_path, output_dir, audit_model, top_n_features, audit_only=True,
             symbol=symbol, timeframe=timeframe,
-            train_data=train_data, test_data=test_data, asset_type=asset_type
         )
         print(f"Feature audit completed. Selected {len(top_features)} features.")
     
@@ -1049,9 +1043,6 @@ def main():
             audit_only=True,
             symbol=args.symbol,
             timeframe=args.timeframe,
-            train_data=args.train_data,
-            test_data=args.test_data,
-            asset_type=args.asset_type,
         )
     elif args.mode == 'single':
         run_single_strategy(

--- a/tests/test_transformer_wrapper.py
+++ b/tests/test_transformer_wrapper.py
@@ -40,3 +40,11 @@ def test_missing_data():
     model.train(df.drop('target',axis=1).fillna(0), df['target'])
     preds = model.predict(df.drop('target',axis=1).fillna(0))
     assert len(preds) == len(df)
+
+
+def test_single_sample_batch():
+    df = make_df(n=6)
+    model = TransformerModelWrapper(seq_length=5, epochs=1, batch_size=4)
+    model.train(df.drop('target', axis=1), df['target'])
+    preds = model.predict(df.drop('target', axis=1))
+    assert len(preds) == len(df)


### PR DESCRIPTION
## Summary
- Simplify `run_feature_audit` interface and update callers in `strategy_runner`
- Correct transformer training loss to handle single-sample batches and add regression test
- Document default confidence thresholds and adaptive threshold usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f7a697d28833082da519d9bb74d5a