### PR TITLE
Handle duplicates and gaps in data loader

### DIFF
--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -5,3 +5,4 @@ Common issues when running transformer or hybrid models.
 * **CUDA not available** – ensure the correct CUDA toolkit is installed and `torch.cuda.is_available()` returns True.
 * **Missing data errors** – check that input DataFrames contain all required feature columns.
 * **Slow inference** – try quantizing the model with `quantization.quantize_transformer` or reduce sequence length.
+* **Data validation warnings** – loaders warn about duplicate timestamps and intraday gaps; examine the messages to confirm they reflect expected market closures.

--- a/src/data/preprocessing.py
+++ b/src/data/preprocessing.py
@@ -5,6 +5,7 @@ Module for preprocessing raw data.
 
 import pandas as pd
 import numpy as np
+import warnings
 from typing import Union, List
 
 # src/data/preprocessing.py (Add this function)
@@ -17,28 +18,68 @@ def _load_csv_files(files: Union[str, List[str]]) -> pd.DataFrame:
     return pd.read_csv(files)
 
 
-def validate_data(df, timeframe='daily'):
-    """Comprehensive data validation."""
-    issues = []
-    if df.index.duplicated().any():
-        issues.append("Duplicate timestamps found")
+def _dedupe_index(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove duplicate index entries and log how many were removed."""
+    before = len(df)
+    df = df[~df.index.duplicated(keep="first")]
+    removed = before - len(df)
+    if removed:
+        print(f"Removed {removed} duplicate timestamps")
+    return df
 
-    if timeframe in ['5min', '1min']:
-        expected_freq = '5T' if timeframe == '5min' else '1T'
-        gaps = df.index.to_series().diff()
-        max_gap = pd.Timedelta(minutes=5 if timeframe == '5min' else 1)
-        if gaps.max() > max_gap * 2:
-            issues.append(f"Large gaps in {timeframe} data")
+
+def _intraday_gap_report(df: pd.DataFrame, timeframe: str) -> List[str]:
+    """Report intraday gaps only during regular market hours."""
+    if timeframe not in ("5min", "1min"):
+        return []
+    idx_eastern = df.index.tz_localize("UTC").tz_convert("America/New_York")
+    df_eastern = df.copy()
+    df_eastern.index = idx_eastern
+    expected = pd.Timedelta(minutes=5 if timeframe == "5min" else 1)
+    issues: List[str] = []
+    for date, group in df_eastern.groupby(df_eastern.index.date):
+        market_hours = group.between_time("09:30", "16:00")
+        if len(market_hours) > 1:
+            gaps = market_hours.index.to_series().diff()
+            large_gaps = gaps[gaps > expected * 2]
+            if not large_gaps.empty:
+                issues.append(f"{len(large_gaps)} intraday gaps on {date}")
+    return issues
+
+
+def validate_data(df, timeframe: str = "daily") -> bool:
+    """Validation with warnings for non-critical issues."""
+    critical_issues: List[str] = []
+
+    if df.index.duplicated().any():
+        dup_count = df.index.duplicated().sum()
+        warnings.warn(
+            f"Found {dup_count} duplicate timestamps",
+            RuntimeWarning,
+        )
+
+    if timeframe in ["5min", "1min"]:
+        gap_issues = _intraday_gap_report(df, timeframe)
+        if gap_issues:
+            warnings.warn(
+                f"Intraday gaps detected: {'; '.join(gap_issues)}",
+                RuntimeWarning,
+            )
 
     for col in df.columns:
-        if 'future' in col.lower() or 'next' in col.lower():
-            issues.append(f"Potential lookahead bias in column: {col}")
+        if "future" in col.lower() or "next" in col.lower():
+            warnings.warn(
+                f"Potential lookahead bias in column: {col}",
+                RuntimeWarning,
+            )
 
     if df.isnull().any().any():
-        issues.append("Missing values detected")
+        critical_issues.append("Missing values detected")
 
-    if issues:
-        raise ValueError(f"Data validation failed: {', '.join(issues)}")
+    if critical_issues:
+        raise ValueError(
+            f"Critical validation failed: {', '.join(critical_issues)}"
+        )
 
     return True
 
@@ -59,34 +100,36 @@ def load_ibkr_data(train_file, test_file):
     pd.DataFrame
         Combined and preprocessed data
     """
-    # Load training and testing data
-    print(f"Loading training data from {train_file}...")
-    train_data = _load_csv_files(train_file)
-
-    print(f"Loading testing data from {test_file}...")
-    test_data = _load_csv_files(test_file)
-    
-    # Combine the data
-    combined_data = pd.concat([train_data, test_data])
+    same_files = (
+        train_file == test_file
+        or (
+            isinstance(train_file, list)
+            and isinstance(test_file, list)
+            and set(train_file) == set(test_file)
+        )
+    )
+    if same_files:
+        print("Train and test reference same file(s); loading once")
+        combined_data = _load_csv_files(train_file)
+    else:
+        print(f"Loading training data from {train_file}...")
+        train_data = _load_csv_files(train_file)
+        print(f"Loading testing data from {test_file}...")
+        test_data = _load_csv_files(test_file)
+        combined_data = pd.concat([train_data, test_data])
     
     # Convert date column to datetime and set as index
     combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
     combined_data['date'] = combined_data['date'].dt.tz_convert('UTC').dt.tz_localize(None)
     combined_data.set_index('date', inplace=True)
-    
-    # Sort by date (no need to reverse since IBKR data is already in chronological order)
+    combined_data = _dedupe_index(combined_data)
     combined_data = combined_data.sort_index()
-    
-    # Make column names lowercase
     combined_data.columns = combined_data.columns.str.lower()
-    
-    # Check for missing values
     missing_count = combined_data.isnull().sum().sum()
     if missing_count > 0:
         print(f"Warning: Found {missing_count} missing values in the data.")
         combined_data = combined_data.dropna()
         print(f"Dropped rows with missing values. New shape: {combined_data.shape}")
-    
     return combined_data
 
 
@@ -106,22 +149,29 @@ def load_5min_data(train_file, test_file):
     pd.DataFrame
         Combined and preprocessed 5-minute data
     """
-    # Load training and testing data
-    print(f"Loading 5-minute training data from {train_file}...")
-    train_data = _load_csv_files(train_file)
-
-    print(f"Loading 5-minute testing data from {test_file}...")
-    test_data = _load_csv_files(test_file)
-    
-    # Combine the data
-    combined_data = pd.concat([train_data, test_data])
+    same_files = (
+        train_file == test_file
+        or (
+            isinstance(train_file, list)
+            and isinstance(test_file, list)
+            and set(train_file) == set(test_file)
+        )
+    )
+    if same_files:
+        print("Train and test reference same file(s); loading once")
+        combined_data = _load_csv_files(train_file)
+    else:
+        print(f"Loading 5-minute training data from {train_file}...")
+        train_data = _load_csv_files(train_file)
+        print(f"Loading 5-minute testing data from {test_file}...")
+        test_data = _load_csv_files(test_file)
+        combined_data = pd.concat([train_data, test_data])
 
     # Convert date column to datetime and handle timezone
     combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
     combined_data['date'] = combined_data['date'].dt.tz_convert('UTC').dt.tz_localize(None)
     combined_data.set_index('date', inplace=True)
-
-    # Sort by date
+    combined_data = _dedupe_index(combined_data)
     combined_data = combined_data.sort_index()
 
     # Make column names lowercase
@@ -158,30 +208,37 @@ def load_1min_data(train_file, test_file):
     pd.DataFrame
         Combined and preprocessed 1-minute data
     """
-    print(f"Loading 1-minute training data from {train_file}...")
-    train_data = _load_csv_files(train_file)
-
-    print(f"Loading 1-minute testing data from {test_file}...")
-    test_data = _load_csv_files(test_file)
-
-    combined_data = pd.concat([train_data, test_data])
+    same_files = (
+        train_file == test_file
+        or (
+            isinstance(train_file, list)
+            and isinstance(test_file, list)
+            and set(train_file) == set(test_file)
+        )
+    )
+    if same_files:
+        print("Train and test reference same file(s); loading once")
+        combined_data = _load_csv_files(train_file)
+    else:
+        print(f"Loading 1-minute training data from {train_file}...")
+        train_data = _load_csv_files(train_file)
+        print(f"Loading 1-minute testing data from {test_file}...")
+        test_data = _load_csv_files(test_file)
+        combined_data = pd.concat([train_data, test_data])
 
     # Parse timestamps and convert to timezone-naive UTC
     combined_data['date'] = pd.to_datetime(combined_data['date'], utc=True)
     combined_data['date'] = combined_data['date'].dt.tz_convert('UTC').dt.tz_localize(None)
     combined_data.set_index('date', inplace=True)
-
+    combined_data = _dedupe_index(combined_data)
     combined_data = combined_data.sort_index()
     combined_data.columns = combined_data.columns.str.lower()
-
     missing_count = combined_data.isnull().sum().sum()
     if missing_count > 0:
         print(f"Warning: Found {missing_count} missing values in the data.")
         combined_data = combined_data.dropna()
         print(f"Dropped rows with missing values. New shape: {combined_data.shape}")
-
     validate_data(combined_data, timeframe='1min')
-
     print(f"1-minute data loaded and preprocessed. Shape: {combined_data.shape}")
     print(f"Date range: {combined_data.index.min()} to {combined_data.index.max()}")
 


### PR DESCRIPTION
## Summary
- warn instead of error on duplicate timestamps and intraday gaps
- drop duplicate index entries when train and test data overlap
- document new validation behavior in troubleshooting guide

## Testing
- `python -m pytest` *(fails: tests/test_transformer_module.py::test_short_sequence_prediction_returns_neutral)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bc39a19c8330802199f025aad18a