### PR TITLE
Add 1-minute lookback and improve intraday handling

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ DATA_TEST_END_DATE = '20240510'  # Testing data end date
 # Model settings
 LOOKBACK_PERIOD = 10  # Number of days to look back for feature creation
 LOOKBACK_PERIOD_5MIN = 78  # Number of 5-minute bars to look back (1 trading day)
+LOOKBACK_PERIOD_1MIN = 390  # Number of 1-minute bars to look back (1 trading day)
 # Note: FEATURE_COUNT removed as it was unused. Feature selection is now handled
 # through the feature auditing and pruning system in feature_engineering.py
 

--- a/docs/operational_workflow.md
+++ b/docs/operational_workflow.md
@@ -49,7 +49,8 @@ Additional tests reside under `tests/` and can be executed with `pytest`.
 ## 7. Configuration
 Adjust thresholds and transaction cost settings in `config.py`:
 - `BUY_THRESHOLD` / `SELL_THRESHOLD`
-- `COMMISSION_RATE` / `SLIPPAGE_RATE`
+- `TRANSACTION_COST` / `SLIPPAGE_RATE` (daily)
+- `TRANSACTION_COST_5MIN` / `SLIPPAGE_5MIN` (intraday)
 
 Default configuration:
 ```python

--- a/feature_analysis_comparison.md
+++ b/feature_analysis_comparison.md
@@ -1,9 +1,10 @@
-# Feature Analysis Comparison: Daily vs 5-Minute Data
+# Feature Analysis Comparison: Daily vs Intraday Data
 
 ## Implementation Summary
 Successfully implemented timeframe-aware feature analysis with appropriate lookback periods:
 - **Daily data**: 10-day lookback period
 - **5-minute data**: 78-bar lookback period (1 trading day)
+- **1-minute data**: 390-bar lookback period (1 trading day)
 
 ## Test Results
 

--- a/src/backtesting/engine.py
+++ b/src/backtesting/engine.py
@@ -19,7 +19,7 @@ class BacktestEngine:
     def __init__(
         self,
         initial_capital: float = 100000.0,
-        commission: float = config.COMMISSION_RATE,
+        commission: float = config.TRANSACTION_COST,
         slippage: float = config.SLIPPAGE_RATE,
     ):
         """
@@ -29,7 +29,7 @@ class BacktestEngine:
         -----------
         initial_capital : float, default=100000.0
             Initial capital for backtesting
-        commission : float, default=config.COMMISSION_RATE
+        commission : float, default=config.TRANSACTION_COST
             Commission rate per trade
         slippage : float, default=config.SLIPPAGE_RATE
             Slippage rate per trade
@@ -90,7 +90,7 @@ class BacktestEngine:
         self.equity_curve.loc[equity_dates[0], 'equity'] = self.initial_capital
         
         # Iterate through signals
-        for date in equity_dates:
+        for i, date in enumerate(equity_dates):
             # Get signals for this date
             date_signals = signals.loc[date]
             
@@ -124,7 +124,7 @@ class BacktestEngine:
                     size_fraction = signal_row.get('position_size', 1.0)
                     available_capital = self.capital * 0.95  # Keep some cash
                     position_size = (available_capital * size_fraction) / price
-                    cost = position_size * price * (1 + self.slippage) * (1 + self.commission)
+                    cost = position_size * price * (1 + self.slippage + self.commission)
                     
                     if cost <= self.capital:
                         self.positions[symbol] = {
@@ -141,7 +141,7 @@ class BacktestEngine:
                     entry_date = position['entry_date']
                     
                     # Calculate proceeds
-                    proceeds = position_size * price * (1 - self.slippage) * (1 - self.commission)
+                    proceeds = position_size * price * (1 - self.slippage - self.commission)
                     self.capital += proceeds
                     
                     # Calculate holding period
@@ -171,6 +171,41 @@ class BacktestEngine:
                     # Remove position
                     del self.positions[symbol]
             
+            # End-of-day flattening for intraday strategies
+            next_date = equity_dates[i + 1] if i + 1 < len(equity_dates) else None
+            if timeframe in ['5min', '5T', '5m', '1min', '1T', '1m'] and (
+                next_date is None or next_date.date() != date.date()
+            ):
+                for symbol, position in list(self.positions.items()):
+                    price_data = data.get(symbol)
+                    if price_data is None or date not in price_data.index:
+                        continue
+                    price = price_data.loc[date, 'close']
+                    if isinstance(price, pd.Series):
+                        price = price.iloc[0]
+                    position_size = position['size']
+                    entry_price = position['entry_price']
+                    entry_date = position['entry_date']
+                    proceeds = position_size * price * (1 - self.slippage - self.commission)
+                    self.capital += proceeds
+                    time_diff = date - entry_date
+                    holding_days = time_diff.days + time_diff.seconds / 86400.0
+                    bars_per_day = 78 if timeframe.startswith('5') else 390
+                    holding_bars = int(holding_days * bars_per_day)
+                    self.trades.append({
+                        'symbol': symbol,
+                        'entry_date': entry_date,
+                        'entry_price': entry_price,
+                        'exit_date': date,
+                        'exit_price': price,
+                        'size': position_size,
+                        'pnl': proceeds - (position_size * entry_price),
+                        'return': (price / entry_price) - 1,
+                        'holding_days': holding_days,
+                        'holding_bars': holding_bars,
+                    })
+                    del self.positions[symbol]
+
             # Update equity curve
             total_position_value = 0.0
             for s, pos in self.positions.items():
@@ -195,7 +230,7 @@ class BacktestEngine:
             exit_price = data[symbol].loc[last_date, 'close']
             
             # Calculate proceeds
-            proceeds = position_size * exit_price * (1 - self.slippage) * (1 - self.commission)
+            proceeds = position_size * exit_price * (1 - self.slippage - self.commission)
             self.capital += proceeds
             
             # Calculate holding period

--- a/src/data/preprocessing.py
+++ b/src/data/preprocessing.py
@@ -130,6 +130,7 @@ def load_ibkr_data(train_file, test_file):
         print(f"Warning: Found {missing_count} missing values in the data.")
         combined_data = combined_data.dropna()
         print(f"Dropped rows with missing values. New shape: {combined_data.shape}")
+    validate_data(combined_data, timeframe='daily')
     return combined_data
 
 

--- a/src/features/feature_engineering.py
+++ b/src/features/feature_engineering.py
@@ -1,10 +1,13 @@
 import numpy as np
 import pandas as pd
+import logging
 from sklearn.preprocessing import StandardScaler
 from sklearn.inspection import permutation_importance
 from sklearn.base import BaseEstimator, ClassifierMixin
 from src.features.indicators import *
 import config
+
+logger = logging.getLogger(__name__)
 
 class ModelAdapter(BaseEstimator, ClassifierMixin):
     """
@@ -254,22 +257,28 @@ def scale_features(X_train, X_test):
     tuple
         (X_train_scaled, X_test_scaled, scaler)
     """
+    if len(X_train) < 100:
+        logger.warning(
+            "Insufficient samples after feature engineering: %d", len(X_train)
+        )
+        return X_train.copy(), X_test.copy(), None
+
     scaler = StandardScaler()
-    
+
     # Fit scaler on training data
     X_train_scaled = pd.DataFrame(
         scaler.fit_transform(X_train),
         columns=X_train.columns,
         index=X_train.index
     )
-    
+
     # Transform test data
     X_test_scaled = pd.DataFrame(
         scaler.transform(X_test),
         columns=X_test.columns,
         index=X_test.index
     )
-    
+
     return X_train_scaled, X_test_scaled, scaler
 
 def audit_features(model, X_train, y_train, X_test, y_test, n_repeats=10, n_top_features=10, random_state=42, threshold=0.5):
@@ -508,7 +517,12 @@ def prepare_train_test_data(df, train_end_date=None, prune_features_flag=False,
         (X_train, X_test, y_train, y_test, dates_train, dates_test, scaler)
     """
     # Determine lookback based on timeframe
-    lookback = config.LOOKBACK_PERIOD_5MIN if timeframe in ['5min', '1min'] else config.LOOKBACK_PERIOD
+    if timeframe == '1min':
+        lookback = getattr(config, 'LOOKBACK_PERIOD_1MIN', 390)
+    elif timeframe == '5min':
+        lookback = config.LOOKBACK_PERIOD_5MIN
+    else:
+        lookback = config.LOOKBACK_PERIOD
 
     # Add technical indicators
     df_features = add_technical_indicators(df, lookback)

--- a/src/models/decision_tree_model.py
+++ b/src/models/decision_tree_model.py
@@ -6,12 +6,13 @@ import os
 import pickle
 import numpy as np
 import pandas as pd
+import logging
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.calibration import CalibratedClassifierCV
-from sklearn.pipeline import make_pipeline, Pipeline
-from sklearn.preprocessing import StandardScaler
 from sklearn.model_selection import TimeSeriesSplit
 from .base_model import BaseModel
+
+logger = logging.getLogger(__name__)
 
 class DecisionTreeModel(BaseModel):
     """
@@ -34,9 +35,9 @@ class DecisionTreeModel(BaseModel):
         """
         return self._base
 
-    def __init__(self, calibrate=False, max_depth=6, min_samples_split=100, min_samples_leaf=50,
+    def __init__(self, calibrate=False, max_depth=6, min_samples_split=100, min_samples_leaf=20,
                  max_features=None, criterion='gini', random_state=42,
-                 ccp_alpha=0.001, class_weight='balanced'):
+                 ccp_alpha=0.0001, class_weight='balanced'):
         """
         Initialize the Decision Tree model.
         
@@ -44,11 +45,11 @@ class DecisionTreeModel(BaseModel):
         -----------
         calibrate : bool, default=False
             Whether to use probability calibration
-        max_depth : int or None, default=5
+        max_depth : int or None, default=6
             Maximum depth of the tree
-        min_samples_split : int, default=2
+        min_samples_split : int, default=100
             Minimum samples required to split an internal node
-        min_samples_leaf : int, default=1
+        min_samples_leaf : int, default=20
             Minimum samples required at a leaf node
         max_features : int, float, str, or None, default=None
             Number of features to consider for best split
@@ -56,7 +57,7 @@ class DecisionTreeModel(BaseModel):
             Function to measure the quality of a split
         random_state : int, default=42
             Random seed for reproducibility
-        ccp_alpha : float, default=0.001
+        ccp_alpha : float, default=0.0001
             Complexity parameter used for Minimal Cost-Complexity Pruning
         class_weight : dict or 'balanced', default='balanced'
             Weights associated with classes to handle imbalance
@@ -73,7 +74,7 @@ class DecisionTreeModel(BaseModel):
         }
         self.calibrate = calibrate
         self._base = DecisionTreeClassifier(**self.params)
-        self._clf = None  # Will hold CalibratedClassifierCV or Pipeline
+        self._clf = None  # Will hold CalibratedClassifierCV or DecisionTreeClassifier
         self.feature_names = None
 
     def train(self, X, y):
@@ -94,20 +95,27 @@ class DecisionTreeModel(BaseModel):
         """
         # Store feature names if available (for feature importance)
         self.feature_names = X.columns if hasattr(X, 'columns') else None
-        
-        # Build a pipeline with scaling
-        pipeline = make_pipeline(StandardScaler(), self._base)
 
         if self.calibrate:
             # Calibrate probabilities using sigmoid (Platt scaling) with time-aware CV
             cv_split = TimeSeriesSplit(n_splits=5)
             self._clf = CalibratedClassifierCV(
-                pipeline, method="sigmoid", cv=cv_split
+                self._base, method="sigmoid", cv=cv_split
             )
             self._clf.fit(X, y)
+            estimator = self._clf.calibrated_classifiers_[0].estimator
         else:
-            self._clf = pipeline
+            self._clf = self._base
             self._clf.fit(X, y)
+            estimator = self._clf
+
+        if hasattr(estimator, "get_depth"):
+            logger.info(
+                "Trained decision tree depth: %d, leaves: %d",
+                estimator.get_depth(),
+                estimator.get_n_leaves(),
+            )
+
         return self
 
     def predict(self, X):
@@ -135,21 +143,14 @@ class DecisionTreeModel(BaseModel):
         dict or np.ndarray
             Feature importance scores
         """
-        # Determine the fitted estimator from the training pipeline
-        estimator = None
-        if isinstance(self._clf, Pipeline):
-            estimator = self._clf.steps[-1][1]
-        elif isinstance(self._clf, CalibratedClassifierCV):
+        # Determine the fitted estimator
+        if isinstance(self._clf, CalibratedClassifierCV):
             if hasattr(self._clf, 'calibrated_classifiers_') and self._clf.calibrated_classifiers_:
-                base = self._clf.calibrated_classifiers_[0].estimator
+                estimator = self._clf.calibrated_classifiers_[0].estimator
             else:
-                base = self._clf.estimator
-            if isinstance(base, Pipeline):
-                estimator = base.steps[-1][1]
-            else:
-                estimator = base
-        elif self._base is not None:
-            estimator = self._base
+                estimator = self._clf.estimator
+        else:
+            estimator = self._clf
 
         if estimator is None or not hasattr(estimator, "feature_importances_"):
             raise ValueError("Model has not been trained yet or does not expose feature_importances_.")

--- a/src/strategies/adapters/bbrsiadx_adapter.py
+++ b/src/strategies/adapters/bbrsiadx_adapter.py
@@ -429,13 +429,23 @@ class BBRSIADXAdapter(BaseStrategy):
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
 
-        commission = self.config.get('commission', config.COMMISSION_RATE)
-        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        timeframe = self.config.get('primary_timeframe', '1h')
+        default_commission = (
+            config.TRANSACTION_COST_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.TRANSACTION_COST
+        )
+        default_slippage = (
+            config.SLIPPAGE_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.SLIPPAGE_RATE
+        )
+        commission = self.config.get('commission', default_commission)
+        slippage = self.config.get('slippage', default_slippage)
         trade_changes = signals['signal'].diff().abs().fillna(0)
         returns -= trade_changes * (commission + slippage)
-        
+
         # Determine annualization factor based on timeframe
-        timeframe = self.config.get('primary_timeframe', '1h')
         if timeframe in ['5min', '5T', '5m']:
             # 5-minute bars: 78 bars per day * 252 trading days
             annualization_factor = np.sqrt(78 * 252)

--- a/src/strategies/adapters/jfk_dsrsi_adapter.py
+++ b/src/strategies/adapters/jfk_dsrsi_adapter.py
@@ -120,12 +120,21 @@ class JFKDSRSIAdapter(BaseStrategy):
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
 
-        commission = self.config.get('commission', config.COMMISSION_RATE)
-        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        timeframe = self.config.get('timeframe', '5min') if hasattr(self, 'config') and self.config else '5min'
+        default_commission = (
+            config.TRANSACTION_COST_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.TRANSACTION_COST
+        )
+        default_slippage = (
+            config.SLIPPAGE_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.SLIPPAGE_RATE
+        )
+        commission = self.config.get('commission', default_commission)
+        slippage = self.config.get('slippage', default_slippage)
         trade_changes = signals['signal'].diff().abs().fillna(0)
         returns -= trade_changes * (commission + slippage)
-
-        timeframe = self.config.get('timeframe', '5min') if hasattr(self, 'config') and self.config else '5min'
         if timeframe in ['5min', '5T', '5m']:
             annualization_factor = np.sqrt(78 * 252)
             periods_per_year = 78 * 252

--- a/src/strategies/adapters/mpo_3tf_adapter.py
+++ b/src/strategies/adapters/mpo_3tf_adapter.py
@@ -121,12 +121,21 @@ class MPO3TFAdapter(BaseStrategy):
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
 
-        commission = self.config.get('commission', config.COMMISSION_RATE)
-        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        timeframe = self.config.get('timeframe', '1min') if hasattr(self, 'config') and self.config else '1min'
+        default_commission = (
+            config.TRANSACTION_COST_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.TRANSACTION_COST
+        )
+        default_slippage = (
+            config.SLIPPAGE_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.SLIPPAGE_RATE
+        )
+        commission = self.config.get('commission', default_commission)
+        slippage = self.config.get('slippage', default_slippage)
         trade_changes = signals['signal'].diff().abs().fillna(0)
         returns -= trade_changes * (commission + slippage)
-
-        timeframe = self.config.get('timeframe', '1min') if hasattr(self, 'config') and self.config else '1min'
         if timeframe in ['1min', '1T', '1m']:
             annualization_factor = np.sqrt(390 * 252)
             periods_per_year = 390 * 252

--- a/src/strategies/adapters/quod_adapter.py
+++ b/src/strategies/adapters/quod_adapter.py
@@ -535,13 +535,23 @@ class QuodAdapter(BaseStrategy):
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
 
-        commission = self.config.get('commission', config.COMMISSION_RATE)
-        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        timeframe = self.config.get('primary_timeframe', '5T')
+        default_commission = (
+            config.TRANSACTION_COST_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.TRANSACTION_COST
+        )
+        default_slippage = (
+            config.SLIPPAGE_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.SLIPPAGE_RATE
+        )
+        commission = self.config.get('commission', default_commission)
+        slippage = self.config.get('slippage', default_slippage)
         trade_changes = signals['signal'].diff().abs().fillna(0)
         returns -= trade_changes * (commission + slippage)
-        
+
         # Determine annualization factor based on timeframe
-        timeframe = self.config.get('primary_timeframe', '5T')
         if timeframe in ['5min', '5T', '5m']:
             # 5-minute bars: 78 bars per day * 252 trading days
             annualization_factor = np.sqrt(78 * 252)

--- a/src/strategies/adapters/tema_adapter.py
+++ b/src/strategies/adapters/tema_adapter.py
@@ -452,13 +452,23 @@ class TEMAAdapter(BaseStrategy):
         position = signals['signal'].shift(1).fillna(0)
         returns = position * aligned_prices['close'].pct_change()
 
-        commission = self.config.get('commission', config.COMMISSION_RATE)
-        slippage = self.config.get('slippage', config.SLIPPAGE_RATE)
+        timeframe = self.config.get('primary_timeframe', '1h')
+        default_commission = (
+            config.TRANSACTION_COST_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.TRANSACTION_COST
+        )
+        default_slippage = (
+            config.SLIPPAGE_5MIN
+            if timeframe in ['5min', '5T', '1min', '1T']
+            else config.SLIPPAGE_RATE
+        )
+        commission = self.config.get('commission', default_commission)
+        slippage = self.config.get('slippage', default_slippage)
         trade_changes = signals['signal'].diff().abs().fillna(0)
         returns -= trade_changes * (commission + slippage)
-        
+
         # Determine annualization factor based on timeframe
-        timeframe = self.config.get('primary_timeframe', '1h')
         if timeframe in ['5min', '5T', '5m']:
             # 5-minute bars: 78 bars per day * 252 trading days
             annualization_factor = np.sqrt(78 * 252)

--- a/src/strategies/trend_following.py
+++ b/src/strategies/trend_following.py
@@ -79,7 +79,12 @@ class TrendFollowingStrategy(BaseStrategy):
             (X, y, dates)
         """
         timeframe = self.config.get('timeframe', 'daily')
-        lookback = config.LOOKBACK_PERIOD_5MIN if timeframe == '5min' else config.LOOKBACK_PERIOD
+        if timeframe == '1min':
+            lookback = getattr(config, 'LOOKBACK_PERIOD_1MIN', 390)
+        elif timeframe == '5min':
+            lookback = config.LOOKBACK_PERIOD_5MIN
+        else:
+            lookback = config.LOOKBACK_PERIOD
         return engineer_features(data, lookback_period=lookback, timeframe=timeframe)
 
     def generate_signals(self, features, predictions, dates):
@@ -273,11 +278,11 @@ class TrendFollowingStrategy(BaseStrategy):
         # Run backtest
         commission = self.config.get(
             'commission',
-            config.TRANSACTION_COST_5MIN if timeframe in ('5min', '5T') else config.TRANSACTION_COST,
+            config.TRANSACTION_COST_5MIN if timeframe in ('5min', '5T', '1min', '1T') else config.TRANSACTION_COST,
         )
         slippage = self.config.get(
             'slippage',
-            config.SLIPPAGE_5MIN if timeframe in ('5min', '5T') else config.SLIPPAGE_RATE,
+            config.SLIPPAGE_5MIN if timeframe in ('5min', '5T', '1min', '1T') else config.SLIPPAGE_RATE,
         )
         backtest_engine = BacktestEngine(
             initial_capital=self.config.get('initial_capital', config.INITIAL_CAPITAL),

--- a/strategy_runner.py
+++ b/strategy_runner.py
@@ -177,7 +177,12 @@ def run_feature_audit(data_path, output_dir, model_type='random_forest',
     
     # Determine lookback period based on timeframe
     intraday = timeframe in ['5min', '1min']
-    lookback_period = config.LOOKBACK_PERIOD_5MIN if intraday else config.LOOKBACK_PERIOD
+    if timeframe == '1min':
+        lookback_period = getattr(config, 'LOOKBACK_PERIOD_1MIN', 390)
+    elif timeframe == '5min':
+        lookback_period = config.LOOKBACK_PERIOD_5MIN
+    else:
+        lookback_period = config.LOOKBACK_PERIOD
     print(f"Using lookback period: {lookback_period} {'bars' if intraday else 'days'}")
     
     # Add technical indicators with appropriate lookback

--- a/tests/test_backtest_engine_intraday.py
+++ b/tests/test_backtest_engine_intraday.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from src.backtesting.engine import BacktestEngine
+
+
+def test_intraday_positions_flattened():
+    dates = pd.to_datetime([
+        '2024-01-02 13:30', '2024-01-02 19:55',
+        '2024-01-03 13:30', '2024-01-03 19:55'
+    ])
+    prices = pd.DataFrame({'close': [100, 101, 102, 103]}, index=dates)
+    signals = pd.DataFrame({
+        'date': dates,
+        'symbol': ['SPY'] * 4,
+        'signal': [1, 0, 1, 0],
+        'probability': [0.6] * 4,
+        'position_size': [1] * 4,
+    }).set_index('date')
+
+    engine = BacktestEngine(initial_capital=100000, commission=0.0, slippage=0.0)
+    result = engine.run_backtest(signals, {'SPY': prices}, timeframe='5min')
+
+    assert engine.positions == {}
+    trades = result['trades']
+    assert len(trades) == 2
+    assert all(trades['exit_date'].dt.date == trades['entry_date'].dt.date)
+


### PR DESCRIPTION
## Summary
- add LOOKBACK_PERIOD_1MIN and wire 1-minute timeframe through strategy runner, feature engineering and trend-following strategy
- relax decision tree regularization and remove unnecessary scaling with training diagnostics
- unify intraday transaction cost handling, fix backtest cost math, flatten intraday positions daily and cover with a new test

## Testing
- `pytest tests/test_decision_tree_model.py tests/test_momentum_adapters.py tests/test_backtest_engine_intraday.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0d7ab3b1c8330a560e4975babc77f