### PR TITLE
Improve strategy execution with EOD flattening and open-price fills

### DIFF
--- a/docs/operational_workflow.md
+++ b/docs/operational_workflow.md
@@ -80,3 +80,35 @@ To analyse multiple symbols or timeframes, run the script in a loop or separate 
 The transformer model now exposes an sklearn-compatible interface. Cross-validation
 works through the `ModelEngine`, but training remains CPU-intensive on macOS.
 
+## 10. Advanced Strategy Execution
+
+### JFK-DSRSI on 5-minute SPX data
+```bash
+python strategy_runner.py \
+  --data data/raw \
+  --model jfk_dsrsi_full \
+  --mode single \
+  --output results/jfk_dsrsi_5min \
+  --timeframe 5min
+```
+
+### MPO-3TF on 1-minute SPX data
+```bash
+python strategy_runner.py \
+  --data data/raw \
+  --model mpo_3tf_full \
+  --mode single \
+  --output results/mpo_3tf_1min \
+  --timeframe 1min
+```
+
+### Compare both strategies
+```bash
+python strategy_runner.py \
+  --data data/raw \
+  --mode compare \
+  --include-momentum \
+  --output results/momentum_comparison \
+  --timeframe 5min
+```
+

--- a/src/strategies/adapters/jfk_dsrsi_adapter.py
+++ b/src/strategies/adapters/jfk_dsrsi_adapter.py
@@ -256,6 +256,10 @@ class JFKDSRSIAdapter(BaseStrategy):
         # Apply KPS exit thresholds
         signals.loc[exit_long_cond & (signals['signal'].shift(1) == 1), 'signal'] = 0
         signals.loc[exit_short_cond & (signals['signal'].shift(1) == -1), 'signal'] = 0
+
+        # End-of-day flattening
+        eod_mask = (signals.index.hour == 15) & (signals.index.minute == 59)
+        signals.loc[eod_mask, 'signal'] = 0
         
         # Stop loss calculation
         if self.use_sl:
@@ -319,6 +323,14 @@ class JFKDSRSIAdapter(BaseStrategy):
         for i in range(len(managed)):
             bar = prices.iloc[i]
             sig = managed.iloc[i]['signal']
+            ts = prices.index[i]
+            if ts.hour == 15 and ts.minute == 59:
+                managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                position = 0
+                stop = target = trail_act = trail_off = None
+                if self.diagnostics:
+                    logger.debug(f"EOD flatten at {ts}")
+                continue
             if position == 0:
                 if sig != 0:
                     position = sig
@@ -326,6 +338,8 @@ class JFKDSRSIAdapter(BaseStrategy):
                     target = managed.iloc[i].get('take_profit')
                     trail_act = managed.iloc[i].get('trail_activation')
                     trail_off = managed.iloc[i].get('trail_offset')
+                    if self.diagnostics:
+                        logger.debug(f"Position opened {position} at {ts}")
                 continue
 
             # Update trailing stop
@@ -351,9 +365,13 @@ class JFKDSRSIAdapter(BaseStrategy):
 
             if exit_trade:
                 managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                if self.diagnostics:
+                    logger.debug(f"Position closed at {ts}")
                 position = 0
                 stop = target = trail_act = trail_off = None
             else:
+                if position != sig and self.diagnostics:
+                    logger.debug(f"Position changed from {position} to {sig} at {ts}")
                 managed.iloc[i, managed.columns.get_loc('signal')] = position
 
         if self.diagnostics:
@@ -364,7 +382,7 @@ class JFKDSRSIAdapter(BaseStrategy):
     def _calculate_backtest_metrics(self, signals: pd.DataFrame, prices: pd.DataFrame) -> Dict[str, any]:
         aligned_prices = prices.loc[signals.index]
         position = signals['signal'].shift(1).fillna(0)
-        returns = position * aligned_prices['close'].pct_change()
+        returns = position * aligned_prices['open'].pct_change()
 
         timeframe = self.config.get('timeframe', '5min') if hasattr(self, 'config') and self.config else '5min'
         default_commission = (

--- a/src/strategies/adapters/jfk_dsrsi_full_adapter.py
+++ b/src/strategies/adapters/jfk_dsrsi_full_adapter.py
@@ -353,6 +353,9 @@ class JFKDSRSIFullAdapter(BaseStrategy):
             signals['trail_offset'] = trail_offset
 
         signals['position_size'] = np.where(signals['signal'] != 0, self.position_size, 0)
+        # End-of-day flattening
+        eod_mask = (signals.index.hour == 15) & (signals.index.minute == 59)
+        signals.loc[eod_mask, 'signal'] = 0
         if self.diagnostics:
             long_entries = (signals['signal'].diff() == 1).sum()
             short_entries = (signals['signal'].diff() == -1).sum()
@@ -369,6 +372,14 @@ class JFKDSRSIFullAdapter(BaseStrategy):
         for i in range(len(managed)):
             bar = prices.iloc[i]
             sig = managed.iloc[i]['signal']
+            ts = prices.index[i]
+            if ts.hour == 15 and ts.minute == 59:
+                managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                position = 0
+                stop = target = trail_act = trail_off = None
+                if self.diagnostics:
+                    logger.debug(f"EOD flatten at {ts}")
+                continue
             if position == 0:
                 if sig != 0:
                     position = sig
@@ -376,6 +387,8 @@ class JFKDSRSIFullAdapter(BaseStrategy):
                     target = managed.iloc[i].get('take_profit')
                     trail_act = managed.iloc[i].get('trail_activation')
                     trail_off = managed.iloc[i].get('trail_offset')
+                    if self.diagnostics:
+                        logger.debug(f"Position opened {position} at {ts}")
                 continue
 
             if trail_act is not None and not np.isnan(trail_act):
@@ -400,9 +413,13 @@ class JFKDSRSIFullAdapter(BaseStrategy):
 
             if exit_trade:
                 managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                if self.diagnostics:
+                    logger.debug(f"Position closed at {ts}")
                 position = 0
                 stop = target = trail_act = trail_off = None
             else:
+                if position != sig and self.diagnostics:
+                    logger.debug(f"Position changed from {position} to {sig} at {ts}")
                 managed.iloc[i, managed.columns.get_loc('signal')] = position
 
         if self.diagnostics:
@@ -414,7 +431,7 @@ class JFKDSRSIFullAdapter(BaseStrategy):
         """Calculate backtest metrics."""
         aligned_prices = prices.loc[signals.index]
         position = signals['signal'].shift(1).fillna(0)
-        returns = position * aligned_prices['close'].pct_change()
+        returns = position * aligned_prices['open'].pct_change()
         
         # Get timeframe for proper annualization
         timeframe = self.config.get('timeframe', '5min') if hasattr(self, 'config') and self.config else '5min'

--- a/src/strategies/adapters/mpo_3tf_adapter.py
+++ b/src/strategies/adapters/mpo_3tf_adapter.py
@@ -284,6 +284,11 @@ class MPO3TFAdapter(BaseStrategy):
 
         position = 0
         for i in range(len(signals)):
+            current_time = dates[i]
+            if current_time.hour == 15 and current_time.minute == 59:
+                signals.iloc[i, signals.columns.get_loc('signal')] = 0
+                position = 0
+                continue
             if position == 0:
                 if entry_signals.iloc[i]['long_entry']:
                     signals.iloc[i, signals.columns.get_loc('signal')] = 1
@@ -291,8 +296,18 @@ class MPO3TFAdapter(BaseStrategy):
                 elif entry_signals.iloc[i]['short_entry']:
                     signals.iloc[i, signals.columns.get_loc('signal')] = -1
                     position = -1
+            elif position == 1:
+                if entry_signals.iloc[i]['short_entry']:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = -1
+                    position = -1
+                else:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = 1
             else:
-                signals.iloc[i, signals.columns.get_loc('signal')] = position
+                if entry_signals.iloc[i]['long_entry']:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = 1
+                    position = 1
+                else:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = -1
 
         atr = features['atr']
         close = features['close']
@@ -325,11 +340,21 @@ class MPO3TFAdapter(BaseStrategy):
         for i in range(len(managed)):
             bar = prices.iloc[i]
             sig = managed.iloc[i]['signal']
+            ts = prices.index[i]
+            if ts.hour == 15 and ts.minute == 59:
+                managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                position = 0
+                stop = target = None
+                if self.diagnostics:
+                    logger.debug(f"EOD flatten at {ts}")
+                continue
             if position == 0:
                 if sig != 0:
                     position = sig
                     stop = managed.iloc[i].get('stop_loss')
                     target = managed.iloc[i].get('take_profit')
+                    if self.diagnostics:
+                        logger.debug(f"Position opened {position} at {ts}")
                 continue
 
             exit_trade = False
@@ -346,9 +371,13 @@ class MPO3TFAdapter(BaseStrategy):
 
             if exit_trade:
                 managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                if self.diagnostics:
+                    logger.debug(f"Position closed at {ts}")
                 position = 0
                 stop = target = None
             else:
+                if position != sig and self.diagnostics:
+                    logger.debug(f"Position changed from {position} to {sig} at {ts}")
                 managed.iloc[i, managed.columns.get_loc('signal')] = position
 
         if self.diagnostics:
@@ -359,7 +388,7 @@ class MPO3TFAdapter(BaseStrategy):
     def _calculate_backtest_metrics(self, signals: pd.DataFrame, prices: pd.DataFrame) -> Dict[str, any]:
         aligned_prices = prices.loc[signals.index]
         position = signals['signal'].shift(1).fillna(0)
-        returns = position * aligned_prices['close'].pct_change()
+        returns = position * aligned_prices['open'].pct_change()
 
         timeframe = self.config.get('timeframe', '1min') if hasattr(self, 'config') and self.config else '1min'
         default_commission = (

--- a/src/strategies/adapters/mpo_3tf_full_adapter.py
+++ b/src/strategies/adapters/mpo_3tf_full_adapter.py
@@ -315,10 +315,15 @@ class MPO3TFFullAdapter(BaseStrategy):
         signals['symbol'] = self.config.get('symbol', 'SPY') if hasattr(self, 'config') and self.config else 'SPY'
         signals['signal'] = 0
         signals['entry_price'] = features['close']
-        
+
         # Process signals
         position = 0
         for i in range(len(signals)):
+            current_time = dates[i]
+            if current_time.hour == 15 and current_time.minute == 59:
+                signals.iloc[i, signals.columns.get_loc('signal')] = 0
+                position = 0
+                continue
             if position == 0:
                 # Check for entries
                 if entry_signals.iloc[i]['long_entry']:
@@ -327,9 +332,18 @@ class MPO3TFFullAdapter(BaseStrategy):
                 elif entry_signals.iloc[i]['short_entry']:
                     signals.iloc[i, signals.columns.get_loc('signal')] = -1
                     position = -1
+            elif position == 1:
+                if entry_signals.iloc[i]['short_entry']:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = -1
+                    position = -1
+                else:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = 1
             else:
-                # Maintain position (exits handled by stop loss/take profit)
-                signals.iloc[i, signals.columns.get_loc('signal')] = position
+                if entry_signals.iloc[i]['long_entry']:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = 1
+                    position = 1
+                else:
+                    signals.iloc[i, signals.columns.get_loc('signal')] = -1
         
         # Add risk management levels
         atr = features['atr']
@@ -374,6 +388,14 @@ class MPO3TFFullAdapter(BaseStrategy):
         for i in range(len(managed)):
             bar = prices.iloc[i]
             sig = managed.iloc[i]['signal']
+            ts = prices.index[i]
+            if ts.hour == 15 and ts.minute == 59:
+                managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                position = 0
+                stop = target = trail_act = trail_off = None
+                if self.diagnostics:
+                    logger.debug(f"EOD flatten at {ts}")
+                continue
             if position == 0:
                 if sig != 0:
                     position = sig
@@ -381,6 +403,8 @@ class MPO3TFFullAdapter(BaseStrategy):
                     target = managed.iloc[i].get('take_profit')
                     trail_act = managed.iloc[i].get('trail_activation')
                     trail_off = managed.iloc[i].get('trail_offset')
+                    if self.diagnostics:
+                        logger.debug(f"Position opened {position} at {ts}")
                 continue
 
             if trail_act is not None and not np.isnan(trail_act):
@@ -405,9 +429,13 @@ class MPO3TFFullAdapter(BaseStrategy):
 
             if exit_trade:
                 managed.iloc[i, managed.columns.get_loc('signal')] = 0
+                if self.diagnostics:
+                    logger.debug(f"Position closed at {ts}")
                 position = 0
                 stop = target = trail_act = trail_off = None
             else:
+                if position != sig and self.diagnostics:
+                    logger.debug(f"Position changed from {position} to {sig} at {ts}")
                 managed.iloc[i, managed.columns.get_loc('signal')] = position
 
         if self.diagnostics:
@@ -419,7 +447,7 @@ class MPO3TFFullAdapter(BaseStrategy):
         """Calculate backtest metrics."""
         aligned_prices = prices.loc[signals.index]
         position = signals['signal'].shift(1).fillna(0)
-        returns = position * aligned_prices['close'].pct_change()
+        returns = position * aligned_prices['open'].pct_change()
         
         # Get timeframe for proper annualization
         timeframe = self.config.get('timeframe', '1min') if hasattr(self, 'config') and self.config else '1min'


### PR DESCRIPTION
## Summary
- Handle opposing signals and end-of-day flattening in MPO-3TF and JFK-DSRSI adapters
- Add intrabar exit logging and enforce market order execution using next bar's open
- Document CLI commands for full strategy runs and comparisons

## Testing
- `pytest tests/test_mpo3tf_adapter.py tests/test_jfk_dsrsi_adapter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a2e0c46270833098662a1fbc619f4c